### PR TITLE
chore: add `--warnings-as-errors` to our test runs

### DIFF
--- a/.github/workflows/elixir.yaml
+++ b/.github/workflows/elixir.yaml
@@ -72,4 +72,4 @@ jobs:
               run: mix credo
 
             - name: Run tests
-              run: mix test
+              run: mix test --warnings-as-errors


### PR DESCRIPTION
resolves #59 