### PR TITLE
feat: add simple auth for api endpoints

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -23,7 +23,15 @@ end
 config :poker_mind, PokerMindWeb.Endpoint,
   http: [port: String.to_integer(System.get_env("PORT", "4000"))]
 
+if config_env() != :prod do
+  config :poker_mind, :api_auth_secret, System.get_env("API_AUTH_SECRET", "test-secret")
+end
+
 if config_env() == :prod do
+  config :poker_mind,
+         :api_auth_secret,
+         System.get_env("API_AUTH_SECRET") || raise("Missing API_AUTH_SECRET")
+
   # The secret key base is used to sign/encrypt cookies and other secrets.
   # A default value is used in config/dev.exs and config/test.exs but you
   # want to use a different value for prod and you most likely don't want

--- a/lib/poker_mind_web/api_auth.ex
+++ b/lib/poker_mind_web/api_auth.ex
@@ -1,0 +1,15 @@
+defmodule PokerMindWeb.ApiAuth do
+  import Plug.Conn
+
+  def fetch_token_and_verify(conn, _opts) do
+    with [secret] <- get_req_header(conn, "authorization"),
+         true <- secret == Application.get_env(:poker_mind, :api_auth_secret) do
+      conn
+    else
+      _ ->
+        conn
+        |> send_resp(:unauthorized, "No access for you my friend")
+        |> halt()
+    end
+  end
+end

--- a/lib/poker_mind_web/router.ex
+++ b/lib/poker_mind_web/router.ex
@@ -1,5 +1,6 @@
 defmodule PokerMindWeb.Router do
   use PokerMindWeb, :router
+  import PokerMindWeb.ApiAuth, only: [fetch_token_and_verify: 2]
 
   pipeline :browser do
     plug :accepts, ["html"]
@@ -12,6 +13,7 @@ defmodule PokerMindWeb.Router do
 
   pipeline :api do
     plug :accepts, ["json"]
+    plug :fetch_token_and_verify
   end
 
   scope "/api", PokerMindWeb do

--- a/test/poker_mind_web/api_auth_test.exs
+++ b/test/poker_mind_web/api_auth_test.exs
@@ -1,0 +1,12 @@
+defmodule PokerMindWeb.ApiAuthTest do
+  use PokerMindWeb.ConnCase, async: true
+
+  test "Can't access endpoint without auth header", %{conn: conn} do
+    conn =
+      conn
+      |> delete_req_header("authorization")
+      |> get("/api/next_games", %{"player_id" => "rolf", "suite_id" => UUID.uuid4()})
+
+    assert response(conn, 401)
+  end
+end

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -32,6 +32,8 @@ defmodule PokerMindWeb.ConnCase do
   end
 
   setup _tags do
-    {:ok, conn: Phoenix.ConnTest.build_conn()}
+    secret = Application.get_env(:poker_mind, :api_auth_secret)
+    conn = Phoenix.ConnTest.build_conn() |> Plug.Conn.put_req_header("authorization", secret)
+    {:ok, conn: conn}
   end
 end


### PR DESCRIPTION
resolves #76 

I add the authorization header to all tests using ConnCase so we don't have to do it manually. 