### PR TITLE
feat: add `all_match_suites` to Match dynamic supervisor

### DIFF
--- a/lib/poker_mind/Engine/match/coordinator.ex
+++ b/lib/poker_mind/Engine/match/coordinator.ex
@@ -39,16 +39,18 @@ defmodule PokerMind.Engine.Match.Coordinator do
     all_games_finished?: false,
     all_games_ready?: false,
     games: %{},
-    num_games: nil
+    num_games: nil,
+    players: nil
   }
 
   @impl true
   def init(init_args) do
     name = Keyword.fetch!(init_args, :name)
     num_games = Keyword.fetch!(init_args, :num_games)
+    players = Keyword.fetch!(init_args, :players)
     Process.set_label(name)
 
-    state = Map.put(@init_state, :num_games, num_games)
+    state = %{@init_state | num_games: num_games, players: players}
 
     {:ok, state}
   end
@@ -113,7 +115,7 @@ defmodule PokerMind.Engine.Match.Coordinator do
       end)
       |> Kernel.then(fn {game_ids, _count} ->
         Enum.map(game_ids, fn game_id ->
-          Game.get_state(game_id)
+          Game.get_state(game_id) |> Map.get(:game)
         end)
       end)
 

--- a/lib/poker_mind/Engine/match/game.ex
+++ b/lib/poker_mind/Engine/match/game.ex
@@ -61,6 +61,6 @@ defmodule PokerMind.Engine.Match.Game do
 
   @impl true
   def handle_call(:get_state, _from, state) do
-    {:reply, state.game, state}
+    {:reply, state, state}
   end
 end

--- a/lib/poker_mind/Engine/match/suite.ex
+++ b/lib/poker_mind/Engine/match/suite.ex
@@ -20,7 +20,7 @@ defmodule PokerMind.Engine.Match.Suite do
 
     coordinator =
       Supervisor.child_spec(
-        {Coordinator, name: coordinator_id, num_games: num_games},
+        {Coordinator, name: coordinator_id, num_games: num_games, players: players},
         id: {Coordinator, coordinator_id}
       )
 

--- a/lib/poker_mind/Engine/match/supervisor.ex
+++ b/lib/poker_mind/Engine/match/supervisor.ex
@@ -1,5 +1,6 @@
 defmodule PokerMind.Engine.Match.Supervisor do
   use DynamicSupervisor
+  alias PokerMind.Engine.Match.Coordinator
   alias PokerMind.Engine.Match.Suite
 
   def start_link(init_arg) do
@@ -20,6 +21,22 @@ defmodule PokerMind.Engine.Match.Supervisor do
   def close_match_suite(suite_id) do
     [{pid, _value}] = Registry.lookup(PokerMind.Engine.Registry, suite_id)
     DynamicSupervisor.terminate_child(__MODULE__, pid)
+  end
+
+  def all_match_suites() do
+    __MODULE__
+    |> DynamicSupervisor.which_children()
+    |> Enum.flat_map(fn
+      {_, pid, _, _} when is_pid(pid) ->
+        Registry.keys(PokerMind.Engine.Registry, pid)
+
+      _ ->
+        []
+    end)
+    |> Map.new(fn suite_id ->
+      %{players: players} = Coordinator.get_state(Coordinator.id(suite_id))
+      {suite_id, players}
+    end)
   end
 
   # Callbacks

--- a/lib/poker_mind_web/controllers/game_controller.ex
+++ b/lib/poker_mind_web/controllers/game_controller.ex
@@ -3,8 +3,13 @@ defmodule PokerMindWeb.GameController do
 
   alias PokerMind.Engine.Match.Coordinator
   alias PokerMind.Engine.Match.Game
+  alias PokerMind.Engine.Match.Supervisor, as: MatchSupervisor
   alias PokerMind.Engine.TableState
   alias PokerMind.Engine.TableState.PlayerState
+
+  def suites(conn, _params) do
+    json(conn, %{data: MatchSupervisor.all_match_suites()})
+  end
 
   def next_games(conn, %{"player_id" => player_id, "suite_id" => suite_id}) do
     coordinator_id = Coordinator.id(suite_id)

--- a/lib/poker_mind_web/router.ex
+++ b/lib/poker_mind_web/router.ex
@@ -18,6 +18,7 @@ defmodule PokerMindWeb.Router do
     pipe_through :api
 
     get "/next_games", GameController, :next_games
+    get "/suites", GameController, :suites
     post "/action", GameController, :perform_action
   end
 

--- a/test/poker_mind/Engine/match/coordinator_test.exs
+++ b/test/poker_mind/Engine/match/coordinator_test.exs
@@ -156,8 +156,9 @@ defmodule PokerMind.Engine.Match.CoordinatorTest do
     test "register_game_ready/3 returns {:error, :game_not_found} when coordinator exists but game does not" do
       coordinator_id = UUID.uuid4()
       game_id = UUID.uuid4()
+      player = "rolf"
 
-      start_supervised!({Coordinator, name: coordinator_id, num_games: 1})
+      start_supervised!({Coordinator, name: coordinator_id, num_games: 1, players: [player]})
 
       assert {:error, :game_not_found} =
                Coordinator.register_game_ready(coordinator_id, game_id, "rolf")
@@ -174,11 +175,12 @@ defmodule PokerMind.Engine.Match.CoordinatorTest do
     test "register_game_finished/3 returns {:error, :game_not_found} when coordinator exists but game does not" do
       coordinator_id = UUID.uuid4()
       game_id = UUID.uuid4()
+      player = "rolf"
 
-      start_supervised!({Coordinator, name: coordinator_id, num_games: 1})
+      start_supervised!({Coordinator, name: coordinator_id, num_games: 1, players: [player]})
 
       assert {:error, :game_not_found} =
-               Coordinator.register_game_finished(coordinator_id, game_id, "rolf")
+               Coordinator.register_game_finished(coordinator_id, game_id, player)
     end
   end
 end

--- a/test/poker_mind/Engine/match/coordinator_test.exs
+++ b/test/poker_mind/Engine/match/coordinator_test.exs
@@ -10,7 +10,9 @@ defmodule PokerMind.Engine.Match.CoordinatorTest do
       coordinator_id = UUID.uuid4()
       num_games = 2
 
-      start_supervised!({Coordinator, name: coordinator_id, num_games: num_games})
+      start_supervised!(
+        {Coordinator, name: coordinator_id, num_games: num_games, players: ["rolf"]}
+      )
 
       assert %{all_games_ready?: false, num_games: ^num_games, games: %{}} =
                Coordinator.get_state(coordinator_id)
@@ -19,7 +21,7 @@ defmodule PokerMind.Engine.Match.CoordinatorTest do
     test "newly initialized Coordinator is ready when all games are ready" do
       coordinator_id = UUID.uuid4()
 
-      start_supervised!({Coordinator, name: coordinator_id, num_games: 2})
+      start_supervised!({Coordinator, name: coordinator_id, num_games: 2, players: ["rolf"]})
 
       game1_id = UUID.uuid4()
       Coordinator.register_game_ready(coordinator_id, game1_id, "rolf")
@@ -36,7 +38,9 @@ defmodule PokerMind.Engine.Match.CoordinatorTest do
       player = "rolf"
       num_games = 2
 
-      start_supervised!({Coordinator, name: coordinator_id, num_games: num_games})
+      start_supervised!(
+        {Coordinator, name: coordinator_id, num_games: num_games, players: [player]}
+      )
 
       assert %{} = _game_state = Coordinator.get_state(coordinator_id)
       start_supervised!({Game, name: game_id, players: [player], coordinator_id: coordinator_id})
@@ -64,7 +68,9 @@ defmodule PokerMind.Engine.Match.CoordinatorTest do
       num_games = 15
       take_amount = 5
 
-      start_supervised!({Coordinator, name: coordinator_id, num_games: num_games})
+      start_supervised!(
+        {Coordinator, name: coordinator_id, num_games: num_games, players: ["stine", "rolf"]}
+      )
 
       Enum.each(1..num_games, fn num ->
         players =
@@ -96,7 +102,9 @@ defmodule PokerMind.Engine.Match.CoordinatorTest do
     winning_player = "rolf"
     num_games = 1
 
-    start_supervised!({Coordinator, name: coordinator_id, num_games: num_games})
+    start_supervised!(
+      {Coordinator, name: coordinator_id, num_games: num_games, players: [winning_player]}
+    )
 
     start_supervised!(
       Supervisor.child_spec(

--- a/test/poker_mind/Engine/match/game_test.exs
+++ b/test/poker_mind/Engine/match/game_test.exs
@@ -7,17 +7,18 @@ defmodule PokerMind.Engine.Match.GameTest do
     suite_id = UUID.uuid4()
     coordinator_id = Coordinator.id(suite_id)
     game_id = Game.id(suite_id, 1)
+    player = "stine"
 
     start_supervised!(
       Supervisor.child_spec(
-        {Coordinator, name: coordinator_id, num_games: 1},
+        {Coordinator, name: coordinator_id, num_games: 1, players: [player]},
         id: {Coordinator, coordinator_id}
       )
     )
 
     start_supervised!(
       Supervisor.child_spec(
-        {Game, name: game_id, players: ["stine"], coordinator_id: coordinator_id},
+        {Game, name: game_id, players: [player], coordinator_id: coordinator_id},
         id: game_id
       )
     )

--- a/test/poker_mind/Engine/match/supervisor_test.exs
+++ b/test/poker_mind/Engine/match/supervisor_test.exs
@@ -2,6 +2,7 @@ defmodule PokerMind.Engine.Match.SupervisorTest do
   use ExUnit.Case, async: true
 
   alias PokerMind.Engine.Match.Supervisor, as: MatchSupervisor
+  alias PokerMindWeb.MatchSupport
 
   describe "PokerMind.Engine.Match.Supervisor" do
     test "can start multiple children" do
@@ -20,6 +21,26 @@ defmodule PokerMind.Engine.Match.SupervisorTest do
       assert id1 != id2
       assert Process.alive?(pid1)
       assert Process.alive?(pid2)
+    end
+
+    test "all_match_suites/0 returns a map of suite_id to players" do
+      suite1_id = UUID.uuid4()
+      suite2_id = UUID.uuid4()
+      players1 = ["rolf", "stine"]
+      players2 = ["asbjørn"]
+
+      {:ok, _, ^suite1_id} = MatchSupport.start_match_suite!(suite1_id, players1)
+      {:ok, _, ^suite2_id} = MatchSupport.start_match_suite!(suite2_id, players2)
+
+      on_exit(fn ->
+        MatchSupervisor.close_match_suite(suite1_id)
+        MatchSupervisor.close_match_suite(suite2_id)
+      end)
+
+      suites = MatchSupervisor.all_match_suites()
+
+      assert suites[suite1_id] == players1
+      assert suites[suite2_id] == players2
     end
   end
 end

--- a/test/poker_mind_web/controllers/game_controller_test.exs
+++ b/test/poker_mind_web/controllers/game_controller_test.exs
@@ -102,24 +102,25 @@ defmodule PokerMind.Engine.Match.GameControllerTest do
     assert %{"data" => suites} = json_response(conn, 200)
     assert suites[suite1_id] == players1
     assert suites[suite2_id] == players2
+  end
 
-    test "POST /api/action with non-existent game_id returns 404", %{conn: conn} do
-      conn =
-        post(conn, "/api/action", %{
-          "player_id" => "rolf",
-          "game_id" => UUID.uuid4(),
-          "action" => "fold"
-        })
+  test "POST /api/action with non-existent game_id returns 404", %{conn: conn} do
+    conn =
+      conn
+      |> post("/api/action", %{
+        "player_id" => "rolf",
+        "game_id" => UUID.uuid4(),
+        "action" => "fold"
+      })
 
-      assert json_response(conn, :not_found) == %{"error" => "Game not found"}
-    end
+    assert json_response(conn, :not_found) == %{"error" => "Game not found"}
+  end
 
-    test "POST /api/action without player_id, game_id and action", %{conn: conn} do
-      conn = post(conn, "/api/action")
+  test "POST /api/action without player_id, game_id and action", %{conn: conn} do
+    conn = post(conn, "/api/action")
 
-      assert json_response(conn, :bad_request) == %{
-               "error" => "player_id, game_id and action are required"
-             }
-    end
+    assert json_response(conn, :bad_request) == %{
+             "error" => "player_id, game_id and action are required"
+           }
   end
 end

--- a/test/poker_mind_web/controllers/game_controller_test.exs
+++ b/test/poker_mind_web/controllers/game_controller_test.exs
@@ -78,6 +78,26 @@ defmodule PokerMind.Engine.Match.GameControllerTest do
     assert state["id"] == game_id
   end
 
+  test "GET /api/suites returns all running suites with their players", %{conn: conn} do
+    suite1_id = UUID.uuid4()
+    suite2_id = UUID.uuid4()
+    players1 = ["rolf", "stine"]
+    players2 = ["asbjørn"]
+
+    {:ok, _pid, ^suite1_id} = MatchSupport.start_match_suite!(suite1_id, players1)
+    {:ok, _pid, ^suite2_id} = MatchSupport.start_match_suite!(suite2_id, players2)
+
+    on_exit(fn ->
+      MatchSupervisor.close_match_suite(suite1_id)
+      MatchSupervisor.close_match_suite(suite2_id)
+    end)
+
+    conn = get(conn, "/api/suites")
+    assert %{"data" => suites} = json_response(conn, 200)
+    assert suites[suite1_id] == players1
+    assert suites[suite2_id] == players2
+  end
+
   test "POST /api/action without player_id, game_id and action", %{conn: conn} do
     conn = post(conn, "/api/action")
 

--- a/test/poker_mind_web/controllers/game_controller_test.exs
+++ b/test/poker_mind_web/controllers/game_controller_test.exs
@@ -102,23 +102,24 @@ defmodule PokerMind.Engine.Match.GameControllerTest do
     assert %{"data" => suites} = json_response(conn, 200)
     assert suites[suite1_id] == players1
     assert suites[suite2_id] == players2
-    
-  test "POST /api/action with non-existent game_id returns 404", %{conn: conn} do
-    conn =
-      post(conn, "/api/action", %{
-        "player_id" => "rolf",
-        "game_id" => UUID.uuid4(),
-        "action" => "fold"
-      })
 
-    assert json_response(conn, :not_found) == %{"error" => "Game not found"}
-  end
+    test "POST /api/action with non-existent game_id returns 404", %{conn: conn} do
+      conn =
+        post(conn, "/api/action", %{
+          "player_id" => "rolf",
+          "game_id" => UUID.uuid4(),
+          "action" => "fold"
+        })
 
-  test "POST /api/action without player_id, game_id and action", %{conn: conn} do
-    conn = post(conn, "/api/action")
+      assert json_response(conn, :not_found) == %{"error" => "Game not found"}
+    end
 
-    assert json_response(conn, :bad_request) == %{
-             "error" => "player_id, game_id and action are required"
-           }
+    test "POST /api/action without player_id, game_id and action", %{conn: conn} do
+      conn = post(conn, "/api/action")
+
+      assert json_response(conn, :bad_request) == %{
+               "error" => "player_id, game_id and action are required"
+             }
+    end
   end
 end


### PR DESCRIPTION
we need a way to present all current matches