### PR TITLE
feat: split_pot (only main pot, no sidepot)

### DIFF
--- a/lib/poker_mind/Engine/playerstate.ex
+++ b/lib/poker_mind/Engine/playerstate.ex
@@ -47,6 +47,15 @@ defmodule PokerMind.Engine.TableState.PlayerState do
     )
   end
 
+  def add_chips(%TableState{} = state, player_id, amount)
+      when is_integer(amount) and amount > 0 do
+    update_in(
+      state,
+      [Access.key(:players), Access.find(&(&1.id == player_id)), Access.key(:remaining_chips)],
+      fn current_chips -> current_chips + amount end
+    )
+  end
+
   def update_current_bet(%TableState{} = state, player_id, amount)
       when is_integer(amount) do
     update_in(

--- a/lib/poker_mind/Engine/tablestate.ex
+++ b/lib/poker_mind/Engine/tablestate.ex
@@ -305,4 +305,37 @@ defmodule PokerMind.Engine.TableState do
 
     Poker.hand_compare(best_hand1, best_hand2)
   end
+
+  # TODO handle sidepot
+  def split_pot(%__MODULE__{} = state, winners) when is_list(winners) do
+    leftover_chips = rem(state.pot, length(winners))
+    winning_chips = div(state.pot - leftover_chips, length(winners))
+
+    # Distribute leftover chips one for each winner, starting with the first winning player
+    new_state =
+      if leftover_chips > 0 do
+        Enum.reduce(0..(leftover_chips - 1), state, fn i, current_state ->
+          winner_id = Enum.at(winners, i)
+          player = get_player(current_state, winner_id)
+          set_player_value(current_state, winner_id, :remaining_chips, player.remaining_chips + 1)
+        end)
+      else
+        state
+      end
+
+    # Distribute winnings to all winners
+    final_state =
+      Enum.reduce(winners, new_state, fn winner_id, current_state ->
+        player = get_player(current_state, winner_id)
+
+        set_player_value(
+          current_state,
+          winner_id,
+          :remaining_chips,
+          player.remaining_chips + winning_chips
+        )
+      end)
+
+    Map.put(final_state, :pot, 0)
+  end
 end

--- a/lib/poker_mind/Engine/tablestate.ex
+++ b/lib/poker_mind/Engine/tablestate.ex
@@ -316,8 +316,7 @@ defmodule PokerMind.Engine.TableState do
       if leftover_chips > 0 do
         Enum.reduce(0..(leftover_chips - 1), state, fn i, current_state ->
           winner_id = Enum.at(winners, i)
-          player = get_player(current_state, winner_id)
-          set_player_value(current_state, winner_id, :remaining_chips, player.remaining_chips + 1)
+          PlayerState.add_chips(current_state, winner_id, 1)
         end)
       else
         state
@@ -326,14 +325,7 @@ defmodule PokerMind.Engine.TableState do
     # Distribute winnings to all winners
     final_state =
       Enum.reduce(winners, new_state, fn winner_id, current_state ->
-        player = get_player(current_state, winner_id)
-
-        set_player_value(
-          current_state,
-          winner_id,
-          :remaining_chips,
-          player.remaining_chips + winning_chips
-        )
+        PlayerState.add_chips(current_state, winner_id, winning_chips)
       end)
 
     Map.put(final_state, :pot, 0)

--- a/test/poker_mind/Engine/tablestate_test.exs
+++ b/test/poker_mind/Engine/tablestate_test.exs
@@ -195,4 +195,67 @@ defmodule PokerMind.Engine.TableStateTest do
 
     assert TableState.compare_hands(player1_hand, player2_hand, community_cards) == :lt
   end
+
+  test "split_pot/2 - one winner, no leftover chips",
+       %{
+         state: state
+       } do
+    new_state =
+      state
+      |> TableState.set_player_value("simon", :remaining_chips, 0)
+      |> TableState.set_player_value("asbjørn", :remaining_chips, 0)
+      |> TableState.set_player_value("rolf", :remaining_chips, 0)
+      |> Map.put(:pot, 100)
+
+    winners = ["simon"]
+
+    final_state = TableState.split_pot(new_state, winners)
+
+    assert final_state.pot == 0
+    assert TableState.get_player(final_state, "simon").remaining_chips == 100
+    assert TableState.get_player(final_state, "asbjørn").remaining_chips == 0
+    assert TableState.get_player(final_state, "rolf").remaining_chips == 0
+  end
+
+  test "split_pot/2 - two winners, one leftover chip for the first winning player",
+       %{
+         state: state
+       } do
+    new_state =
+      state
+      |> TableState.set_player_value("simon", :remaining_chips, 0)
+      |> TableState.set_player_value("asbjørn", :remaining_chips, 0)
+      |> TableState.set_player_value("rolf", :remaining_chips, 0)
+      |> Map.put(:pot, 101)
+
+    winners = ["asbjørn", "rolf"]
+
+    final_state = TableState.split_pot(new_state, winners)
+
+    assert final_state.pot == 0
+    assert TableState.get_player(final_state, "simon").remaining_chips == 0
+    assert TableState.get_player(final_state, "asbjørn").remaining_chips == 51
+    assert TableState.get_player(final_state, "rolf").remaining_chips == 50
+  end
+
+  test "split_pot/2 - three winners, two leftover chip, one for the first winning player and one for the second winning player",
+       %{
+         state: state
+       } do
+    new_state =
+      state
+      |> TableState.set_player_value("simon", :remaining_chips, 0)
+      |> TableState.set_player_value("asbjørn", :remaining_chips, 0)
+      |> TableState.set_player_value("rolf", :remaining_chips, 0)
+      |> Map.put(:pot, 101)
+
+    winners = ["simon", "asbjørn", "rolf"]
+
+    final_state = TableState.split_pot(new_state, winners)
+
+    assert final_state.pot == 0
+    assert TableState.get_player(final_state, "simon").remaining_chips == 34
+    assert TableState.get_player(final_state, "asbjørn").remaining_chips == 34
+    assert TableState.get_player(final_state, "rolf").remaining_chips == 33
+  end
 end


### PR DESCRIPTION
Resolves part of #62 

Handles splitting the pot among winners and distributing any leftover chips, with each extra chip going to the next winner in order.
