### PR TITLE
fix: reset highest raise to zero

### DIFF
--- a/lib/poker_mind/Engine/actions.ex
+++ b/lib/poker_mind/Engine/actions.ex
@@ -127,10 +127,10 @@ defmodule PokerMind.Engine.Actions do
       player.current_bet == amount ->
         {:error, "Current_bet = new raise amount - did we already perform this bet?"}
 
-      amount < 2 * state.highest_raise ->
+      amount < 2 * state.big_blind_amount ->
         {:error, "Not a valid raise - assume bet size too small"}
 
-      amount >= 2 * state.highest_raise ->
+      amount >= 2 * state.big_blind_amount ->
         :ok
 
       true ->

--- a/lib/poker_mind/Engine/tablestate.ex
+++ b/lib/poker_mind/Engine/tablestate.ex
@@ -359,7 +359,7 @@ defmodule PokerMind.Engine.TableState do
   end
 
   def reset_highest_raise(%__MODULE__{} = state) do
-    Map.put(state, :highest_raise, state.big_blind_amount)
+    Map.put(state, :highest_raise, 0)
   end
 
   def compare_cards(rank1, rank2)

--- a/test/poker_mind/Engine/actions_test.exs
+++ b/test/poker_mind/Engine/actions_test.exs
@@ -494,14 +494,14 @@ defmodule PokerMind.Engine.ActionsTest do
       assert Actions.apply_action(init_state, %{
                type: :raise,
                player_id: starting_player_id,
-               amount: 2 * init_state.highest_raise
+               amount: 2 * init_state.big_blind_amount
              }) == {:error, "Current_bet = new raise amount - did we already perform this bet?"}
 
       assert %TableState{} =
                Actions.apply_action(init_state, %{
                  type: :raise,
                  player_id: starting_player_id,
-                 amount: 8 * init_state.highest_raise
+                 amount: 8 * init_state.big_blind_amount
                })
     end
   end

--- a/test/poker_mind/Engine/actions_test.exs
+++ b/test/poker_mind/Engine/actions_test.exs
@@ -586,7 +586,7 @@ defmodule PokerMind.Engine.ActionsTest do
         end)
 
       assert final.phase == :flop
-      assert final.highest_raise == init_state.big_blind_amount
+      assert final.highest_raise == 0
       assert Enum.all?(final.players, &(&1.current_bet == 0))
       assert Enum.all?(final.players, &(not &1.has_acted))
 

--- a/test/poker_mind/Engine/tablestate_test.exs
+++ b/test/poker_mind/Engine/tablestate_test.exs
@@ -683,9 +683,9 @@ defmodule PokerMind.Engine.TableStateTest do
   end
 
   describe " reset of betting round helpers" do
-    test "reset_highest_raise/1 - resets highest_raise to big_blind_amount", %{state: state} do
+    test "reset_highest_raise/1 - resets highest_raise to 0", %{state: state} do
       state = Map.put(state, :highest_raise, 500)
-      assert TableState.reset_highest_raise(state).highest_raise == state.big_blind_amount
+      assert TableState.reset_highest_raise(state).highest_raise == 0
     end
 
     test "reset_current_bet/1 - zeros current_bet for all players", %{state: state} do


### PR DESCRIPTION
We need to reset highest raise to zero between betting rounds, such that it is possible to only check.
When validating raise, we use big_blind_amount instead as intended