### PR TITLE
fix/reject-fold-when-caller-is-last-player

### DIFF
--- a/lib/poker_mind/Engine/actions.ex
+++ b/lib/poker_mind/Engine/actions.ex
@@ -18,7 +18,8 @@ defmodule PokerMind.Engine.Actions do
 
   def apply_action(%TableState{} = state, %{type: :fold, player_id: player_id})
       when is_binary(player_id) do
-    with :ok <- validate_turn(state, player_id) do
+    with :ok <- validate_turn(state, player_id),
+         :ok <- validate_fold(state, player_id) do
       state
       |> TableState.set_player_value(player_id, :state, :inactive_in_hand)
       |> advance_player_turn(:fold)
@@ -117,6 +118,20 @@ defmodule PokerMind.Engine.Actions do
       true ->
         {:error,
          "Action requires more chips than player has remaining - if you want to go all in use the all_in action type"}
+    end
+  end
+
+  defp validate_fold(%TableState{players: players}, player_id) do
+    others_still_live =
+      Enum.any?(players, fn p ->
+        p.id != player_id and p.state in [:active_in_hand, :all_in]
+      end)
+
+    if others_still_live do
+      :ok
+    else
+      {:error,
+       {:cannot_fold_last_player, "Cannot fold when no other players are still in the hand"}}
     end
   end
 

--- a/lib/poker_mind/Engine/actions.ex
+++ b/lib/poker_mind/Engine/actions.ex
@@ -122,12 +122,12 @@ defmodule PokerMind.Engine.Actions do
   end
 
   defp validate_fold(%TableState{players: players}, player_id) do
-    others_still_live =
+    other_players_still_active? =
       Enum.any?(players, fn p ->
         p.id != player_id and p.state in [:active_in_hand, :all_in]
       end)
 
-    if others_still_live do
+    if other_players_still_active? do
       :ok
     else
       {:error,

--- a/lib/poker_mind/Engine/actions.ex
+++ b/lib/poker_mind/Engine/actions.ex
@@ -134,6 +134,9 @@ defmodule PokerMind.Engine.Actions do
     else
       {:error,
        {:cannot_fold_last_player, "Cannot fold when no other players are still in the hand"}}
+    end
+  end
+
   defp validate_call(%TableState{highest_raise: highest_raise}, amount) when is_integer(amount) do
     if amount == highest_raise do
       :ok

--- a/test/poker_mind/Engine/actions_test.exs
+++ b/test/poker_mind/Engine/actions_test.exs
@@ -68,16 +68,16 @@ defmodule PokerMind.Engine.ActionsTest do
       # handle_showdown then called split_pot([]), which evaluated rem(pot, 0) and
       # crashed the engine. validate_fold/2 must reject this case.
 
-      [last_live | others] = init_state.players
+      [last_active_player  | other_players] = init_state.players
 
       players =
-        [%{last_live | state: :active_in_hand, has_acted: false}] ++
-          Enum.map(others, &%{&1 | state: :inactive_in_hand})
+        [%{last_active_player  | state: :active_in_hand, has_acted: false}] ++
+          Enum.map(other_players, &%{&1 | state: :inactive_in_hand})
 
-      state = %{init_state | players: players, current_player_id: last_live.id}
+      state = %{init_state | players: players, current_player_id: last_active_player.id}
 
       assert {:error, {:cannot_fold_last_player, _}} =
-               Actions.apply_action(state, %{type: :fold, player_id: last_live.id})
+               Actions.apply_action(state, %{type: :fold, player_id: last_active_player.id})
     end
   end
 

--- a/test/poker_mind/Engine/actions_test.exs
+++ b/test/poker_mind/Engine/actions_test.exs
@@ -61,6 +61,24 @@ defmodule PokerMind.Engine.ActionsTest do
       # next player has to act
       assert starting_player_id != fold_state.current_player_id
     end
+
+    test "rejects fold when caller is the last live player", %{state: init_state} do
+      # Regression: previously, if every other seat was already :inactive_in_hand,
+      # the current player could fold themselves out too — leaving zero contestants.
+      # handle_showdown then called split_pot([]), which evaluated rem(pot, 0) and
+      # crashed the engine. validate_fold/2 must reject this case.
+
+      [last_live | others] = init_state.players
+
+      players =
+        [%{last_live | state: :active_in_hand, has_acted: false}] ++
+          Enum.map(others, &%{&1 | state: :inactive_in_hand})
+
+      state = %{init_state | players: players, current_player_id: last_live.id}
+
+      assert {:error, {:cannot_fold_last_player, _}} =
+               Actions.apply_action(state, %{type: :fold, player_id: last_live.id})
+    end
   end
 
   describe "apply_action :check" do

--- a/test/poker_mind/Engine/actions_test.exs
+++ b/test/poker_mind/Engine/actions_test.exs
@@ -68,16 +68,16 @@ defmodule PokerMind.Engine.ActionsTest do
       # handle_showdown then called split_pot([]), which evaluated rem(pot, 0) and
       # crashed the engine. validate_fold/2 must reject this case.
 
-      [last_live | others] = init_state.players
+      [last_active_player | other_players] = init_state.players
 
       players =
-        [%{last_live | state: :active_in_hand, has_acted: false}] ++
-          Enum.map(others, &%{&1 | state: :inactive_in_hand})
+        [%{last_active_player | state: :active_in_hand, has_acted: false}] ++
+          Enum.map(other_players, &%{&1 | state: :inactive_in_hand})
 
-      state = %{init_state | players: players, current_player_id: last_live.id}
+      state = %{init_state | players: players, current_player_id: last_active_player.id}
 
       assert {:error, {:cannot_fold_last_player, _}} =
-               Actions.apply_action(state, %{type: :fold, player_id: last_live.id})
+               Actions.apply_action(state, %{type: :fold, player_id: last_active_player.id})
     end
   end
 

--- a/test/poker_mind/Engine/tablestate_test.exs
+++ b/test/poker_mind/Engine/tablestate_test.exs
@@ -377,6 +377,26 @@ defmodule PokerMind.Engine.TableStateTest do
     end
   end
 
+  describe "set_current_player_for_phase/1" do
+    test "post-flop fallback when small blind is inactive picks next active player",
+         %{state: state} do
+      # Regression: post-flop the phase starter is the small blind. When the
+      # small blind is not :active_in_hand, the fallback used to pass the
+      # player struct into find_next_active_player/2, which is guarded by
+      # is_binary/1 — raising FunctionClauseError.
+      result =
+        state
+        |> Map.put(:phase, :flop)
+        |> TableState.set_player_value(state.small_blind_id, :state, :inactive_in_hand)
+        |> TableState.set_current_player_for_phase()
+
+      assert result.current_player_id != state.small_blind_id
+
+      assert TableState.get_player(result, result.current_player_id).state ==
+               :active_in_hand
+    end
+  end
+
   describe "complete_current_player_turn/1" do
     test "complete_current_player_turn/1 - current players `has_acted` is set to `true`", %{
       state: state


### PR DESCRIPTION
bug-fix#2 som resultat af property tests:

## Fix
Add `validate_fold/2`, plug it into the `:fold` `with` chain.

## summary
- `:fold` only validated turn order. If every other seat was already
  `:inactive_in_hand` (folded earlier this hand), the current player could
  fold themselves out too — leaving zero contestants.
- `handle_showdown` then calls `split_pot([])`, which evaluates
  `rem(pot, 0)` and crashes the engine.
