### PR TITLE
Added validate call to confirm call == highest_raise

### DIFF
--- a/lib/poker_mind/Engine/actions.ex
+++ b/lib/poker_mind/Engine/actions.ex
@@ -28,6 +28,7 @@ defmodule PokerMind.Engine.Actions do
   def apply_action(%TableState{} = state, %{type: :call, player_id: player_id, amount: amount})
       when is_binary(player_id) do
     with :ok <- validate_turn(state, player_id),
+         :ok <- validate_call(state, amount),
          :ok <- validate_amount(state, player_id, amount) do
       state
       |> TableState.add_to_pot(player_id, amount)
@@ -117,6 +118,15 @@ defmodule PokerMind.Engine.Actions do
       true ->
         {:error,
          "Action requires more chips than player has remaining - if you want to go all in use the all_in action type"}
+    end
+  end
+
+  defp validate_call(%TableState{highest_raise: highest_raise}, amount) when is_integer(amount) do
+    if amount == highest_raise do
+      :ok
+    else
+      {:error,
+       {:invalid_call_amount, "Call amount #{amount} must match highest raise #{highest_raise}"}}
     end
   end
 

--- a/test/poker_mind/Engine/actions_test.exs
+++ b/test/poker_mind/Engine/actions_test.exs
@@ -185,14 +185,14 @@ defmodule PokerMind.Engine.ActionsTest do
           amount: 2 * init_state.highest_raise
         })
 
-      # next player calls
+      # next player calls — must match the new highest_raise
       next_player_id = new_state.current_player_id
 
       new_state =
         Actions.apply_action(new_state, %{
           type: :call,
           player_id: next_player_id,
-          amount: init_state.highest_raise
+          amount: 2 * init_state.highest_raise
         })
 
       # check that the calling player is still :active_in_hand
@@ -200,14 +200,54 @@ defmodule PokerMind.Engine.ActionsTest do
 
       # pot size should be updated with the call amount
       assert new_state.pot ==
-               init_state.pot + 2 * init_state.big_blind_amount + init_state.highest_raise
+               init_state.pot + 2 * init_state.big_blind_amount + 2 * init_state.highest_raise
 
       # check that next player has the correct remaining chips after the call
       next_player_remaining_chips =
         TableState.get_player(new_state, next_player_id).remaining_chips
 
       # check that chips were deducted from next player stack
-      assert next_player_remaining_chips == starting_stack - init_state.highest_raise
+      assert next_player_remaining_chips == starting_stack - 2 * init_state.highest_raise
+    end
+
+    test "call rejects amount less than highest_raise", %{state: init_state} do
+      starting_player_id = init_state.current_player_id
+
+      raised_state =
+        Actions.apply_action(init_state, %{
+          type: :raise,
+          player_id: starting_player_id,
+          amount: 2 * init_state.highest_raise
+        })
+
+      next_player_id = raised_state.current_player_id
+
+      assert {:error, {:invalid_call_amount, _}} =
+               Actions.apply_action(raised_state, %{
+                 type: :call,
+                 player_id: next_player_id,
+                 amount: init_state.highest_raise
+               })
+    end
+
+    test "call rejects amount greater than highest_raise", %{state: init_state} do
+      starting_player_id = init_state.current_player_id
+
+      raised_state =
+        Actions.apply_action(init_state, %{
+          type: :raise,
+          player_id: starting_player_id,
+          amount: 2 * init_state.highest_raise
+        })
+
+      next_player_id = raised_state.current_player_id
+
+      assert {:error, {:invalid_call_amount, _}} =
+               Actions.apply_action(raised_state, %{
+                 type: :call,
+                 player_id: next_player_id,
+                 amount: 3 * init_state.highest_raise
+               })
     end
   end
 


### PR DESCRIPTION
## Fix
Add `validate_call/2` requiring `amount == state.highest_raise`.

## Summary
- `:call` ran only `validate_turn` + `validate_amount`. `validate_amount` checks
  the player has enough chips and `amount > 0`, but **does not** check that the
  amount equals the current bet. A caller could pass any positive integer.
- Two failure modes:
  - **Underbet**: `add_to_pot` computes `amount - current_bet`, which goes
    negative once `current_bet > amount`. Chip conservation breaks; pot accounting silently drifts.
  - **Overbet**: state goes through, but `highest_raise` is not updated, so subsequent players' calls/raises validate against a stale baseline.