### PR TITLE
fix: total contributed is reset

### DIFF
--- a/lib/poker_mind/Engine/tablestate.ex
+++ b/lib/poker_mind/Engine/tablestate.ex
@@ -509,6 +509,7 @@ defmodule PokerMind.Engine.TableState do
           |> set_player_value(player.id, :current_hand, [])
           |> set_player_value(player.id, :current_bet, 0)
           |> set_player_value(player.id, :has_acted, false)
+          |> set_player_value(player.id, :total_contributed, 0)
           |> reset_player_state(player)
         end)
 

--- a/test/poker_mind/Engine/tablestate_test.exs
+++ b/test/poker_mind/Engine/tablestate_test.exs
@@ -332,6 +332,7 @@ defmodule PokerMind.Engine.TableStateTest do
         assert updated_player.current_bet == 0 or
                  updated_player.current_bet == 50 or
                  updated_player.current_bet == 100
+
         # Total_contributed depends on whether the player is chosen as small_blind or big_blind
         assert updated_player.total_contributed == 0 or
                  updated_player.total_contributed == 50 or

--- a/test/poker_mind/Engine/tablestate_test.exs
+++ b/test/poker_mind/Engine/tablestate_test.exs
@@ -332,6 +332,10 @@ defmodule PokerMind.Engine.TableStateTest do
         assert updated_player.current_bet == 0 or
                  updated_player.current_bet == 50 or
                  updated_player.current_bet == 100
+        # Total_contributed depends on whether the player is chosen as small_blind or big_blind
+        assert updated_player.total_contributed == 0 or
+                 updated_player.total_contributed == 50 or
+                 updated_player.total_contributed == 100
 
         assert updated_player.has_acted == false
         assert updated_player.state == :active_in_hand


### PR DESCRIPTION
Reset total contributed when starting a new hand (the chips have been split, and no one should have contributed anything, when starting a new hand)