### PR TITLE
check next phase in advance_player_turn

### DIFF
--- a/lib/poker_mind/Engine/actions.ex
+++ b/lib/poker_mind/Engine/actions.ex
@@ -170,17 +170,17 @@ defmodule PokerMind.Engine.Actions do
     if TableState.round_complete?(updated_state) do
       next_phase = TableState.next_phase(state)
 
-      advanced =
+      advanced_state =
         state
         |> TableState.reset_has_acted()
         |> TableState.reset_current_bet()
         |> TableState.reset_highest_raise()
         |> TableState.advance_phase(next_phase)
 
-      if advanced.phase in [:flop, :turn, :river] do
-        TableState.set_current_player_for_phase(advanced)
+      if advanced_state.phase in [:flop, :turn, :river] do
+        TableState.set_current_player_for_phase(advanced_state)
       else
-        advanced
+        advanced_state
       end
     else
       next_player = TableState.find_next_active_player(updated_state, state.current_player_id)

--- a/lib/poker_mind/Engine/actions.ex
+++ b/lib/poker_mind/Engine/actions.ex
@@ -177,12 +177,18 @@ defmodule PokerMind.Engine.Actions do
     if TableState.round_complete?(updated_state) do
       next_phase = TableState.next_phase(state)
 
-      state
-      |> TableState.reset_has_acted()
-      |> TableState.reset_current_bet()
-      |> TableState.reset_highest_raise()
-      |> TableState.advance_phase(next_phase)
-      |> TableState.set_current_player_for_phase()
+      advanced =
+        state
+        |> TableState.reset_has_acted()
+        |> TableState.reset_current_bet()
+        |> TableState.reset_highest_raise()
+        |> TableState.advance_phase(next_phase)
+
+      if advanced.phase in [:flop, :turn, :river] do
+        TableState.set_current_player_for_phase(advanced)
+      else
+        advanced
+      end
     else
       next_player_id =
         TableState.find_next_active_player_id(updated_state, state.current_player_id)

--- a/lib/poker_mind/Engine/actions.ex
+++ b/lib/poker_mind/Engine/actions.ex
@@ -177,17 +177,17 @@ defmodule PokerMind.Engine.Actions do
     if TableState.round_complete?(updated_state) do
       next_phase = TableState.next_phase(state)
 
-      advanced =
+      advanced_state =
         state
         |> TableState.reset_has_acted()
         |> TableState.reset_current_bet()
         |> TableState.reset_highest_raise()
         |> TableState.advance_phase(next_phase)
 
-      if advanced.phase in [:flop, :turn, :river] do
-        TableState.set_current_player_for_phase(advanced)
+      if advanced_state.phase in [:flop, :turn, :river] do
+        TableState.set_current_player_for_phase(advanced_state)
       else
-        advanced
+        advanced_state
       end
     else
       next_player_id =

--- a/lib/poker_mind/Engine/actions.ex
+++ b/lib/poker_mind/Engine/actions.ex
@@ -170,12 +170,18 @@ defmodule PokerMind.Engine.Actions do
     if TableState.round_complete?(updated_state) do
       next_phase = TableState.next_phase(state)
 
-      state
-      |> TableState.reset_has_acted()
-      |> TableState.reset_current_bet()
-      |> TableState.reset_highest_raise()
-      |> TableState.advance_phase(next_phase)
-      |> TableState.set_current_player_for_phase()
+      advanced =
+        state
+        |> TableState.reset_has_acted()
+        |> TableState.reset_current_bet()
+        |> TableState.reset_highest_raise()
+        |> TableState.advance_phase(next_phase)
+
+      if advanced.phase in [:flop, :turn, :river] do
+        TableState.set_current_player_for_phase(advanced)
+      else
+        advanced
+      end
     else
       next_player = TableState.find_next_active_player(updated_state, state.current_player_id)
       %{updated_state | current_player_id: next_player.id}

--- a/lib/poker_mind/Engine/actions.ex
+++ b/lib/poker_mind/Engine/actions.ex
@@ -12,6 +12,7 @@ defmodule PokerMind.Engine.Actions do
       state
       |> TableState.add_to_pot(player_id, amount)
       |> TableState.update_highest_raise(amount)
+      |> TableState.update_raise_amount(amount - state.highest_raise)
       |> TableState.reset_has_acted()
       |> advance_player_turn(:raise)
     end
@@ -154,17 +155,19 @@ defmodule PokerMind.Engine.Actions do
     cond do
       player.current_bet == amount ->
         {:error,
-         {:already_performed_raise,
-          "Current_bet = new raise amount - did we already perform this bet?"}}
+         {:current_bet_matches_raise,
+          "Invalid raise, the amount provided #{amount} is equal to your current bet"}}
 
-      amount < 2 * state.big_blind_amount ->
-        {:error, {:invalid_raise, "Not a valid raise - assume bet size too small"}}
+      amount - state.highest_raise < state.raise_amount ->
+        {:error,
+         {:invalid_raise,
+          "Invalid raise, you raised to #{amount}, but the current minimum viable raise is #{state.highest_raise + state.raise_amount}"}}
 
-      amount >= 2 * state.big_blind_amount ->
+      amount - state.highest_raise >= state.raise_amount ->
         :ok
 
       true ->
-        {:error, {:invalid_action, "Not a valid action"}}
+        {:error, {:invalid_action, "Invalid action"}}
     end
   end
 

--- a/lib/poker_mind/Engine/tablestate.ex
+++ b/lib/poker_mind/Engine/tablestate.ex
@@ -23,6 +23,7 @@ defmodule PokerMind.Engine.TableState do
     # bet to match
     :highest_raise,
     :big_blind_amount,
+    :raise_amount,
     :winner,
     :hands_played
   ]
@@ -93,6 +94,7 @@ defmodule PokerMind.Engine.TableState do
     new_state
     |> Map.put(:highest_raise, big_blind)
     |> Map.put(:big_blind_amount, big_blind)
+    |> Map.put(:raise_amount, big_blind)
     |> add_to_pot(new_state.small_blind_id, div(big_blind, 2))
     |> advance_player(:current_player_id, new_state.small_blind_id)
     |> then(fn state ->
@@ -372,6 +374,11 @@ defmodule PokerMind.Engine.TableState do
   def update_highest_raise(%__MODULE__{} = state, amount)
       when is_integer(amount) and amount > 0 do
     Map.put(state, :highest_raise, amount)
+  end
+
+  def update_raise_amount(%__MODULE__{} = state, amount)
+      when is_integer(amount) and amount > 0 do
+    Map.put(state, :raise_amount, amount)
   end
 
   def reset_highest_raise(%__MODULE__{} = state) do

--- a/test/poker_mind/Engine/actions_test.exs
+++ b/test/poker_mind/Engine/actions_test.exs
@@ -691,8 +691,7 @@ defmodule PokerMind.Engine.ActionsTest do
     # set_current_player_for_phase/1 after every phase advance, even when the
     # advance landed on :showdown / :hand_finished / :game_finished — phases
     # where no player can act. With zero :active_in_hand players the fallback
-    # in set_current_player_for_phase/1 returned nil and crashed with
-    # BadMapError on nil.id.
+    # in set_current_player_for_phase/1 returned nil and crashed.
     test "3-player starting_player fold, small_blind all-in, big_blind folds and state reaches showdown without crashing" do
       # Shrunk action sequence from tablestate_property_test seed 353104:
       # starting_player folds; small_blind goes over-the-top all-in (re-opens betting, resets
@@ -716,16 +715,17 @@ defmodule PokerMind.Engine.ActionsTest do
       big_blind = after_small_blind_all_in.current_player_id
       assert big_blind != small_blind and big_blind != starting_player
 
-      final = Actions.apply_action(after_small_blind_all_in, %{type: :fold, player_id: big_blind})
+      final_state =
+        Actions.apply_action(after_small_blind_all_in, %{type: :fold, player_id: big_blind})
 
       # No crash. Phase resolved to :showdown and the pot was refunded to small_blind
       # (the only player still in the hand). small_blind started with 10_000, paid 50
       # in blinds, went all-in for 10_000, and is refunded the full 10_100
       # pot — netting big_blind's 100 forfeit.
-      assert final.phase == :showdown
-      assert final.pot == 0
-      assert TableState.get_player(final, small_blind).remaining_chips == 10_100
-      assert TableState.get_player(final, small_blind).state == :all_in
+      assert final_state.phase == :showdown
+      assert final_state.pot == 0
+      assert TableState.get_player(final_state, small_blind).remaining_chips == 10_100
+      assert TableState.get_player(final_state, small_blind).state == :all_in
     end
 
     test "completing a hand starts the next hand with a valid current_player",

--- a/test/poker_mind/Engine/actions_test.exs
+++ b/test/poker_mind/Engine/actions_test.exs
@@ -760,5 +760,76 @@ defmodule PokerMind.Engine.ActionsTest do
                &(&1.total_contributed == 2 * init_state.big_blind_amount)
              )
     end
+
+    # Regression: previously advance_player_turn/2 unconditionally called
+    # set_current_player_for_phase/1 after every phase advance, even when the
+    # advance landed on :showdown / :hand_finished / :game_finished — phases
+    # where no player can act. With zero :active_in_hand players the fallback
+    # in set_current_player_for_phase/1 returned nil and crashed with
+    # BadMapError on nil.id.
+    test "3-player starting_player fold, small_blind all-in, big_blind folds and state reaches showdown without crashing" do
+      # Shrunk action sequence from tablestate_property_test seed 353104:
+      # starting_player folds; small_blind goes over-the-top all-in (re-opens betting, resets
+      # has_acted across the table); big_blind folds — leaving zero :active_in_hand
+      # players. round_complete? is vacuously true, next_phase is :showdown,
+      # and the pot is uncontested → small_blind is refunded.
+      init_state =
+        TableState.init(TableState.new(UUID.uuid4()), ["asbjørn", "stine", "rolf"])
+
+      starting_player = init_state.current_player_id
+      small_blind = init_state.small_blind_id
+
+      after_starting_player_fold =
+        Actions.apply_action(init_state, %{type: :fold, player_id: starting_player})
+
+      assert after_starting_player_fold.current_player_id == small_blind
+
+      after_small_blind_all_in =
+        Actions.apply_action(after_starting_player_fold, %{type: :all_in, player_id: small_blind})
+
+      big_blind = after_small_blind_all_in.current_player_id
+      assert big_blind != small_blind and big_blind != starting_player
+
+      final = Actions.apply_action(after_small_blind_all_in, %{type: :fold, player_id: big_blind})
+
+      # No crash. Phase resolved to :showdown and the pot was refunded to small_blind
+      # (the only player still in the hand). small_blind started with 10_000, paid 50
+      # in blinds, went all-in for 10_000, and is refunded the full 10_100
+      # pot — netting big_blind's 100 forfeit.
+      assert final.phase == :showdown
+      assert final.pot == 0
+      assert TableState.get_player(final, small_blind).remaining_chips == 10_100
+      assert TableState.get_player(final, small_blind).state == :all_in
+    end
+
+    test "completing a hand starts the next hand with a valid current_player",
+         %{state: init_state} do
+      # The fix excludes :pre_flop from set_current_player_for_phase because
+      # possible_new_hand/1 already sets current_player_id via set_blinds(false).
+      # Verify the next hand still has a valid actor and accepts an action.
+      others = Enum.reject(init_state.players, &(&1.id == init_state.small_blind_id))
+
+      with_only_small_blind_active =
+        Enum.reduce(others, init_state, fn player, acc ->
+          TableState.set_player_value(acc, player.id, :state, :inactive_in_hand)
+        end)
+
+      after_showdown = TableState.advance_phase(with_only_small_blind_active, :showdown)
+      next_hand = TableState.advance_phase(after_showdown, :hand_finished)
+
+      assert next_hand.phase == :pre_flop
+      assert next_hand.winner == nil
+      assert next_hand.current_player_id != nil
+
+      current = TableState.get_player(next_hand, next_hand.current_player_id)
+      assert current.state == :active_in_hand
+
+      # And the engine accepts an action from the new current player.
+      result =
+        Actions.apply_action(next_hand, %{type: :fold, player_id: next_hand.current_player_id})
+
+      refute match?({:error, _}, result)
+      assert TableState.get_player(result, next_hand.current_player_id).state == :inactive_in_hand
+    end
   end
 end

--- a/test/poker_mind/Engine/actions_test.exs
+++ b/test/poker_mind/Engine/actions_test.exs
@@ -686,5 +686,76 @@ defmodule PokerMind.Engine.ActionsTest do
                &(&1.total_contributed == 2 * init_state.big_blind_amount)
              )
     end
+
+    # Regression: previously advance_player_turn/2 unconditionally called
+    # set_current_player_for_phase/1 after every phase advance, even when the
+    # advance landed on :showdown / :hand_finished / :game_finished — phases
+    # where no player can act. With zero :active_in_hand players the fallback
+    # in set_current_player_for_phase/1 returned nil and crashed with
+    # BadMapError on nil.id.
+    test "3-player starting_player fold, small_blind all-in, big_blind folds and state reaches showdown without crashing" do
+      # Shrunk action sequence from tablestate_property_test seed 353104:
+      # starting_player folds; small_blind goes over-the-top all-in (re-opens betting, resets
+      # has_acted across the table); big_blind folds — leaving zero :active_in_hand
+      # players. round_complete? is vacuously true, next_phase is :showdown,
+      # and the pot is uncontested → small_blind is refunded.
+      init_state =
+        TableState.init(TableState.new(UUID.uuid4()), ["asbjørn", "stine", "rolf"])
+
+      starting_player = init_state.current_player_id
+      small_blind = init_state.small_blind_id
+
+      after_starting_player_fold =
+        Actions.apply_action(init_state, %{type: :fold, player_id: starting_player})
+
+      assert after_starting_player_fold.current_player_id == small_blind
+
+      after_small_blind_all_in =
+        Actions.apply_action(after_starting_player_fold, %{type: :all_in, player_id: small_blind})
+
+      big_blind = after_small_blind_all_in.current_player_id
+      assert big_blind != small_blind and big_blind != starting_player
+
+      final = Actions.apply_action(after_small_blind_all_in, %{type: :fold, player_id: big_blind})
+
+      # No crash. Phase resolved to :showdown and the pot was refunded to small_blind
+      # (the only player still in the hand). small_blind started with 10_000, paid 50
+      # in blinds, went all-in for 10_000, and is refunded the full 10_100
+      # pot — netting big_blind's 100 forfeit.
+      assert final.phase == :showdown
+      assert final.pot == 0
+      assert TableState.get_player(final, small_blind).remaining_chips == 10_100
+      assert TableState.get_player(final, small_blind).state == :all_in
+    end
+
+    test "completing a hand starts the next hand with a valid current_player",
+         %{state: init_state} do
+      # The fix excludes :pre_flop from set_current_player_for_phase because
+      # possible_new_hand/1 already sets current_player_id via set_blinds(false).
+      # Verify the next hand still has a valid actor and accepts an action.
+      others = Enum.reject(init_state.players, &(&1.id == init_state.small_blind_id))
+
+      with_only_small_blind_active =
+        Enum.reduce(others, init_state, fn player, acc ->
+          TableState.set_player_value(acc, player.id, :state, :inactive_in_hand)
+        end)
+
+      after_showdown = TableState.advance_phase(with_only_small_blind_active, :showdown)
+      next_hand = TableState.advance_phase(after_showdown, :hand_finished)
+
+      assert next_hand.phase == :pre_flop
+      assert next_hand.winner == nil
+      assert next_hand.current_player_id != nil
+
+      current = TableState.get_player(next_hand, next_hand.current_player_id)
+      assert current.state == :active_in_hand
+
+      # And the engine accepts an action from the new current player.
+      result =
+        Actions.apply_action(next_hand, %{type: :fold, player_id: next_hand.current_player_id})
+
+      refute match?({:error, _}, result)
+      assert TableState.get_player(result, next_hand.current_player_id).state == :inactive_in_hand
+    end
   end
 end

--- a/test/poker_mind/Engine/actions_test.exs
+++ b/test/poker_mind/Engine/actions_test.exs
@@ -562,28 +562,34 @@ defmodule PokerMind.Engine.ActionsTest do
     } do
       starting_player_id = init_state.current_player_id
 
-      updated_state =
+      raise_state =
+        init_state
+        |> TableState.set_player_value(starting_player_id, :current_bet, 2000)
+        |> TableState.set_player_value(starting_player_id, :remaining_chips, 1000)
+        |> Map.put(:highest_raise, 2000)
+
+      # Raising with 2500 is valid even though remaining chips for starting player is 1000
+      # as it already has 2000 chips as current bet
+      assert %TableState{} =
+               Actions.apply_action(raise_state, %{
+                 type: :raise,
+                 player_id: starting_player_id,
+                 amount: 2500
+               })
+
+      call_state =
         init_state
         |> TableState.set_player_value(starting_player_id, :current_bet, 1000)
         |> TableState.set_player_value(starting_player_id, :remaining_chips, 1000)
         |> Map.put(:highest_raise, 2000)
 
-      # Raising with 1500 is valid even though remaining chips for starting player is 1000
-      # as it already has 1000 chips as current bet
-      assert %TableState{} =
-               Actions.apply_action(updated_state, %{
-                 type: :raise,
-                 player_id: starting_player_id,
-                 amount: 1500
-               })
-
-      # Calling with 2000 is valid even though remaining chips for starting player is 1000
-      # as it already has 1000 chips as current bet. Error is do to the player going all_in.
+      # Calling with 2000 is valid for amount even though remaining chips for starting player is 1000
+      # as it already has 1000 chips as current bet. Error is due to the player going all_in.
       assert {:error, {:use_all_in_action, _}} =
-               Actions.apply_action(updated_state, %{
+               Actions.apply_action(call_state, %{
                  type: :call,
                  player_id: starting_player_id,
-                 amount: updated_state.highest_raise
+                 amount: call_state.highest_raise
                })
     end
 
@@ -609,7 +615,7 @@ defmodule PokerMind.Engine.ActionsTest do
         )
 
       # raise amount equal to current bet
-      assert {:error, {:already_performed_raise, _}} =
+      assert {:error, {:current_bet_matches_raise, _}} =
                Actions.apply_action(init_state, %{
                  type: :raise,
                  player_id: starting_player_id,
@@ -621,6 +627,46 @@ defmodule PokerMind.Engine.ActionsTest do
                  type: :raise,
                  player_id: starting_player_id,
                  amount: 8 * init_state.big_blind_amount
+               })
+    end
+
+    test "validate_raise/3 - dynamically update raise_amount within a betting round", %{
+      state: init_state
+    } do
+      starting_player_id = init_state.current_player_id
+
+      # starting player can raise with 1*big_blind as default
+      assert %TableState{} =
+               Actions.apply_action(init_state, %{
+                 type: :raise,
+                 player_id: starting_player_id,
+                 amount: 2 * init_state.big_blind_amount
+               })
+
+      # starting player raises with 2*big_blind
+      next_state =
+        Actions.apply_action(init_state, %{
+          type: :raise,
+          player_id: starting_player_id,
+          amount: 3 * init_state.big_blind_amount
+        })
+
+      next_player_id = next_state.current_player_id
+
+      # The following player cannot raise with 1*big_blind now
+      assert {:error, {:invalid_raise, _}} =
+               Actions.apply_action(next_state, %{
+                 type: :raise,
+                 player_id: next_player_id,
+                 amount: 4 * init_state.big_blind_amount
+               })
+
+      # The following player has to raise with 2*big_blind now
+      assert %TableState{} =
+               Actions.apply_action(next_state, %{
+                 type: :raise,
+                 player_id: next_player_id,
+                 amount: 5 * init_state.big_blind_amount
                })
     end
   end

--- a/test/poker_mind/Engine/actions_test.exs
+++ b/test/poker_mind/Engine/actions_test.exs
@@ -765,8 +765,7 @@ defmodule PokerMind.Engine.ActionsTest do
     # set_current_player_for_phase/1 after every phase advance, even when the
     # advance landed on :showdown / :hand_finished / :game_finished — phases
     # where no player can act. With zero :active_in_hand players the fallback
-    # in set_current_player_for_phase/1 returned nil and crashed with
-    # BadMapError on nil.id.
+    # in set_current_player_for_phase/1 returned nil and crashed.
     test "3-player starting_player fold, small_blind all-in, big_blind folds and state reaches showdown without crashing" do
       # Shrunk action sequence from tablestate_property_test seed 353104:
       # starting_player folds; small_blind goes over-the-top all-in (re-opens betting, resets
@@ -790,16 +789,17 @@ defmodule PokerMind.Engine.ActionsTest do
       big_blind = after_small_blind_all_in.current_player_id
       assert big_blind != small_blind and big_blind != starting_player
 
-      final = Actions.apply_action(after_small_blind_all_in, %{type: :fold, player_id: big_blind})
+      final_state =
+        Actions.apply_action(after_small_blind_all_in, %{type: :fold, player_id: big_blind})
 
       # No crash. Phase resolved to :showdown and the pot was refunded to small_blind
       # (the only player still in the hand). small_blind started with 10_000, paid 50
       # in blinds, went all-in for 10_000, and is refunded the full 10_100
       # pot — netting big_blind's 100 forfeit.
-      assert final.phase == :showdown
-      assert final.pot == 0
-      assert TableState.get_player(final, small_blind).remaining_chips == 10_100
-      assert TableState.get_player(final, small_blind).state == :all_in
+      assert final_state.phase == :showdown
+      assert final_state.pot == 0
+      assert TableState.get_player(final_state, small_blind).remaining_chips == 10_100
+      assert TableState.get_player(final_state, small_blind).state == :all_in
     end
 
     test "completing a hand starts the next hand with a valid current_player",

--- a/test/poker_mind/Engine/actions_test.exs
+++ b/test/poker_mind/Engine/actions_test.exs
@@ -792,21 +792,25 @@ defmodule PokerMind.Engine.ActionsTest do
       final_state =
         Actions.apply_action(after_small_blind_all_in, %{type: :fold, player_id: big_blind})
 
-      # No crash. Phase resolved to :showdown and the pot was refunded to small_blind
-      # (the only player still in the hand). small_blind started with 10_000, paid 50
-      # in blinds, went all-in for 10_000, and is refunded the full 10_100
-      # pot — netting big_blind's 100 forfeit.
-      assert final_state.phase == :showdown
-      assert final_state.pot == 0
+      # No crash. Showdown refunded the uncontested pot to small_blind, then
+      # advance_phase cascaded into a fresh hand via possible_new_hand/1.
+      # small_blind started with 10_000, paid 50 in blinds, went all-in for
+      # 10_000, and was refunded the full 10_100 pot — netting big_blind's 100
+      # forfeit. In a 3-player rotation old SB becomes first-to-act in the new
+      # hand and pays no new blind, so they keep the full 10_100.
+      assert final_state.phase == :pre_flop
       assert TableState.get_player(final_state, small_blind).remaining_chips == 10_100
-      assert TableState.get_player(final_state, small_blind).state == :all_in
+      assert TableState.get_player(final_state, small_blind).state == :active_in_hand
+      assert final_state.current_player_id == small_blind
     end
 
     test "completing a hand starts the next hand with a valid current_player",
          %{state: init_state} do
-      # The fix excludes :pre_flop from set_current_player_for_phase because
-      # possible_new_hand/1 already sets current_player_id via set_blinds(false).
-      # Verify the next hand still has a valid actor and accepts an action.
+      # advance_phase(:showdown) cascades through :hand_finished into the next
+      # hand's :pre_flop. Verify possible_new_hand/1 sets current_player_id
+      # (via set_blinds(false)) so the new hand has a valid actor that can
+      # accept an action — set_current_player_for_phase is intentionally not
+      # called for :pre_flop in advance_player_turn.
       others = Enum.reject(init_state.players, &(&1.id == init_state.small_blind_id))
 
       with_only_small_blind_active =
@@ -814,8 +818,7 @@ defmodule PokerMind.Engine.ActionsTest do
           TableState.set_player_value(acc, player.id, :state, :inactive_in_hand)
         end)
 
-      after_showdown = TableState.advance_phase(with_only_small_blind_active, :showdown)
-      next_hand = TableState.advance_phase(after_showdown, :hand_finished)
+      next_hand = TableState.advance_phase(with_only_small_blind_active, :showdown)
 
       assert next_hand.phase == :pre_flop
       assert next_hand.winner == nil

--- a/test/poker_mind/Engine/tablestate_test.exs
+++ b/test/poker_mind/Engine/tablestate_test.exs
@@ -137,6 +137,9 @@ defmodule PokerMind.Engine.TableStateTest do
           # big blind amount stays the same for the first 9 hands
           assert after_hand_finished.hands_played == i
           assert after_hand_finished.big_blind_amount == state.big_blind_amount
+          # The same for highest_raise and raise_amount
+          assert after_hand_finished.highest_raise == state.highest_raise
+          assert after_hand_finished.raise_amount == state.raise_amount
           after_hand_finished
         end)
 
@@ -147,6 +150,9 @@ defmodule PokerMind.Engine.TableStateTest do
       # big_blind doubles when 10 hands has been played
       assert final_state.phase == :pre_flop
       assert final_state.big_blind_amount == state.big_blind_amount * 2
+      # The same for highest_raise and raise_amount
+      assert final_state.highest_raise == state.highest_raise * 2
+      assert final_state.raise_amount == state.raise_amount * 2
     end
   end
 


### PR DESCRIPTION
## Summary
`advance_player_turn/2` unconditionally calls `set_current_player_for_phase/1`
after every phase advance. That's only correct when the next phase is a
betting round (`:flop`, `:turn`, `:river`). For `:showdown`, `:hand_finished`,
and `:game_finished` no player can act, and for the `:pre_flop` produced by
`possible_new_hand/1` the current player is already set inside `set_blinds/2`.

Calling it in those cases drives `set_current_player_for_phase/1` into a state
with no `:active_in_hand` player remaining, `find_next_active_player/2`
returns `nil`, and the function crashes with `BadMapError` on `nil.id` at
`tablestate.ex:226`.

## Fix
Guard the call by inspecting the *resulting* phase, not the requested
`next_phase` (because `:hand_finished` may produce either `:pre_flop` or
`:game_finished` via `possible_new_hand/1`).