### PR TITLE
fix: validate_amount should also consider current_bet

### DIFF
--- a/lib/poker_mind/Engine/actions.ex
+++ b/lib/poker_mind/Engine/actions.ex
@@ -110,10 +110,10 @@ defmodule PokerMind.Engine.Actions do
     player = TableState.get_player(state, player_id)
 
     cond do
-      amount < player.remaining_chips and amount > 0 ->
+      amount < player.remaining_chips + player.current_bet and amount > 0 ->
         :ok
 
-      amount == player.remaining_chips ->
+      amount == player.remaining_chips + player.current_bet ->
         {:error,
          "Action requires all remaining chips - if you want to go all in use the all_in action type"}
 

--- a/lib/poker_mind/Engine/actions.ex
+++ b/lib/poker_mind/Engine/actions.ex
@@ -114,12 +114,12 @@ defmodule PokerMind.Engine.Actions do
         :ok
 
       amount == player.remaining_chips + player.current_bet ->
-        {:error,
-         "Action requires all remaining chips - if you want to go all in use the all_in action type"}
+        {:error, {:use_all_in_action,
+         "Action requires all remaining chips - if you want to go all in use the all_in action type"}}
 
       true ->
-        {:error,
-         "Action requires more chips than player has remaining - if you want to go all in use the all_in action type"}
+        {:error, {:not_enough_chips,
+         "Action requires more chips than player has remaining - if you want to go all in use the all_in action type"}}
     end
   end
 
@@ -151,16 +151,16 @@ defmodule PokerMind.Engine.Actions do
 
     cond do
       player.current_bet == amount ->
-        {:error, "Current_bet = new raise amount - did we already perform this bet?"}
+        {:error, {:already_performed_raise, "Current_bet = new raise amount - did we already perform this bet?"}}
 
       amount < 2 * state.big_blind_amount ->
-        {:error, "Not a valid raise - assume bet size too small"}
+        {:error, {:invalid_raise, "Not a valid raise - assume bet size too small"}}
 
       amount >= 2 * state.big_blind_amount ->
         :ok
 
       true ->
-        {:error, "Not a valid action"}
+        {:error, {:invalid_action, "Not a valid action"}}
     end
   end
 

--- a/lib/poker_mind/Engine/actions.ex
+++ b/lib/poker_mind/Engine/actions.ex
@@ -114,12 +114,14 @@ defmodule PokerMind.Engine.Actions do
         :ok
 
       amount == player.remaining_chips + player.current_bet ->
-        {:error, {:use_all_in_action,
-         "Action requires all remaining chips - if you want to go all in use the all_in action type"}}
+        {:error,
+         {:use_all_in_action,
+          "Action requires all remaining chips - if you want to go all in use the all_in action type"}}
 
       true ->
-        {:error, {:not_enough_chips,
-         "Action requires more chips than player has remaining - if you want to go all in use the all_in action type"}}
+        {:error,
+         {:not_enough_chips,
+          "Action requires more chips than player has remaining - if you want to go all in use the all_in action type"}}
     end
   end
 
@@ -151,7 +153,9 @@ defmodule PokerMind.Engine.Actions do
 
     cond do
       player.current_bet == amount ->
-        {:error, {:already_performed_raise, "Current_bet = new raise amount - did we already perform this bet?"}}
+        {:error,
+         {:already_performed_raise,
+          "Current_bet = new raise amount - did we already perform this bet?"}}
 
       amount < 2 * state.big_blind_amount ->
         {:error, {:invalid_raise, "Not a valid raise - assume bet size too small"}}

--- a/test/poker_mind/Engine/actions_test.exs
+++ b/test/poker_mind/Engine/actions_test.exs
@@ -541,22 +541,20 @@ defmodule PokerMind.Engine.ActionsTest do
         TableState.get_player(init_state, starting_player_id).remaining_chips
 
       # raise with amount more than players entire stack
-      assert Actions.apply_action(init_state, %{
+      assert {:error, {:not_enough_chips, _}} =
+        Actions.apply_action(init_state, %{
                type: :raise,
                player_id: starting_player_id,
                amount: 3 * player_remaining_chips
-             }) ==
-               {:error,
-                "Action requires more chips than player has remaining - if you want to go all in use the all_in action type"}
+             })
 
       # raise amount equal to player stack
-      assert Actions.apply_action(init_state, %{
+      assert {:error, {:use_all_in_action, _}} =
+      Actions.apply_action(init_state, %{
                type: :raise,
                player_id: starting_player_id,
                amount: player_remaining_chips
-             }) ==
-               {:error,
-                "Action requires all remaining chips - if you want to go all in use the all_in action type"}
+             })
     end
 
     test "validate_amount/3 - remaining_chips and current_bet are both included in amount", %{
@@ -572,7 +570,8 @@ defmodule PokerMind.Engine.ActionsTest do
 
       # Raising with 1500 is valid even though remaining chips for starting player is 1000
       # as it already has 1000 chips as current bet
-      assert Actions.apply_action(updated_state, %{
+      assert %TableState{} =
+        Actions.apply_action(updated_state, %{
                type: :raise,
                player_id: starting_player_id,
                amount: 1500
@@ -580,13 +579,12 @@ defmodule PokerMind.Engine.ActionsTest do
 
       # Calling with 2000 is valid even though remaining chips for starting player is 1000
       # as it already has 1000 chips as current bet. Error is do to the player going all_in.
-      assert Actions.apply_action(updated_state, %{
+      assert {:error, {:use_all_in_action, _}} =
+        Actions.apply_action(updated_state, %{
                type: :call,
                player_id: starting_player_id,
                amount: updated_state.highest_raise
-             }) ==
-               {:error,
-                "Action requires all remaining chips - if you want to go all in use the all_in action type"}
+             })
     end
 
     test "Test of validate_raise helper function", %{state: init_state} do
@@ -594,12 +592,13 @@ defmodule PokerMind.Engine.ActionsTest do
 
       # test error catching in validate_raise
       # raise amount too low
-      assert Actions.apply_action(init_state, %{
+      assert {:error, {:invalid_raise, _}} =
+      Actions.apply_action(init_state, %{
                type: :raise,
                player_id: starting_player_id,
                # assumes big blind is 100
                amount: Integer.floor_div(init_state.big_blind_amount, 2)
-             }) == {:error, "Not a valid raise - assume bet size too small"}
+             })
 
       # set current bet equal to highest raise to test error catching in validate_raise for raise amount equal to current bet
       init_state =
@@ -610,11 +609,12 @@ defmodule PokerMind.Engine.ActionsTest do
         )
 
       # raise amount equal to current bet
-      assert Actions.apply_action(init_state, %{
+      assert {:error, {:already_performed_raise, _}} =
+        Actions.apply_action(init_state, %{
                type: :raise,
                player_id: starting_player_id,
                amount: 2 * init_state.big_blind_amount
-             }) == {:error, "Current_bet = new raise amount - did we already perform this bet?"}
+             })
 
       assert %TableState{} =
                Actions.apply_action(init_state, %{

--- a/test/poker_mind/Engine/actions_test.exs
+++ b/test/poker_mind/Engine/actions_test.exs
@@ -557,8 +557,36 @@ defmodule PokerMind.Engine.ActionsTest do
              }) ==
                {:error,
                 "Action requires all remaining chips - if you want to go all in use the all_in action type"}
+    end
 
-      # test call
+    test "validate_amount/3 - remaining_chips and current_bet are both included in amount", %{
+      state: init_state
+    } do
+      starting_player_id = init_state.current_player_id
+
+      updated_state =
+        init_state
+        |> TableState.set_player_value(starting_player_id, :current_bet, 1000)
+        |> TableState.set_player_value(starting_player_id, :remaining_chips, 1000)
+        |> Map.put(:highest_raise, 2000)
+
+      # Raising with 1500 is valid even though remaining chips for starting player is 1000
+      # as it already has 1000 chips as current bet
+      assert Actions.apply_action(updated_state, %{
+               type: :raise,
+               player_id: starting_player_id,
+               amount: 1500
+             })
+
+      # Calling with 2000 is valid even though remaining chips for starting player is 1000
+      # as it already has 1000 chips as current bet. Error is do to the player going all_in.
+      assert Actions.apply_action(updated_state, %{
+               type: :call,
+               player_id: starting_player_id,
+               amount: updated_state.highest_raise
+             }) ==
+               {:error,
+                "Action requires all remaining chips - if you want to go all in use the all_in action type"}
     end
 
     test "Test of validate_raise helper function", %{state: init_state} do

--- a/test/poker_mind/Engine/actions_test.exs
+++ b/test/poker_mind/Engine/actions_test.exs
@@ -542,19 +542,19 @@ defmodule PokerMind.Engine.ActionsTest do
 
       # raise with amount more than players entire stack
       assert {:error, {:not_enough_chips, _}} =
-        Actions.apply_action(init_state, %{
-               type: :raise,
-               player_id: starting_player_id,
-               amount: 3 * player_remaining_chips
-             })
+               Actions.apply_action(init_state, %{
+                 type: :raise,
+                 player_id: starting_player_id,
+                 amount: 3 * player_remaining_chips
+               })
 
       # raise amount equal to player stack
       assert {:error, {:use_all_in_action, _}} =
-      Actions.apply_action(init_state, %{
-               type: :raise,
-               player_id: starting_player_id,
-               amount: player_remaining_chips
-             })
+               Actions.apply_action(init_state, %{
+                 type: :raise,
+                 player_id: starting_player_id,
+                 amount: player_remaining_chips
+               })
     end
 
     test "validate_amount/3 - remaining_chips and current_bet are both included in amount", %{
@@ -571,20 +571,20 @@ defmodule PokerMind.Engine.ActionsTest do
       # Raising with 1500 is valid even though remaining chips for starting player is 1000
       # as it already has 1000 chips as current bet
       assert %TableState{} =
-        Actions.apply_action(updated_state, %{
-               type: :raise,
-               player_id: starting_player_id,
-               amount: 1500
-             })
+               Actions.apply_action(updated_state, %{
+                 type: :raise,
+                 player_id: starting_player_id,
+                 amount: 1500
+               })
 
       # Calling with 2000 is valid even though remaining chips for starting player is 1000
       # as it already has 1000 chips as current bet. Error is do to the player going all_in.
       assert {:error, {:use_all_in_action, _}} =
-        Actions.apply_action(updated_state, %{
-               type: :call,
-               player_id: starting_player_id,
-               amount: updated_state.highest_raise
-             })
+               Actions.apply_action(updated_state, %{
+                 type: :call,
+                 player_id: starting_player_id,
+                 amount: updated_state.highest_raise
+               })
     end
 
     test "Test of validate_raise helper function", %{state: init_state} do
@@ -593,12 +593,12 @@ defmodule PokerMind.Engine.ActionsTest do
       # test error catching in validate_raise
       # raise amount too low
       assert {:error, {:invalid_raise, _}} =
-      Actions.apply_action(init_state, %{
-               type: :raise,
-               player_id: starting_player_id,
-               # assumes big blind is 100
-               amount: Integer.floor_div(init_state.big_blind_amount, 2)
-             })
+               Actions.apply_action(init_state, %{
+                 type: :raise,
+                 player_id: starting_player_id,
+                 # assumes big blind is 100
+                 amount: Integer.floor_div(init_state.big_blind_amount, 2)
+               })
 
       # set current bet equal to highest raise to test error catching in validate_raise for raise amount equal to current bet
       init_state =
@@ -610,11 +610,11 @@ defmodule PokerMind.Engine.ActionsTest do
 
       # raise amount equal to current bet
       assert {:error, {:already_performed_raise, _}} =
-        Actions.apply_action(init_state, %{
-               type: :raise,
-               player_id: starting_player_id,
-               amount: 2 * init_state.big_blind_amount
-             })
+               Actions.apply_action(init_state, %{
+                 type: :raise,
+                 player_id: starting_player_id,
+                 amount: 2 * init_state.big_blind_amount
+               })
 
       assert %TableState{} =
                Actions.apply_action(init_state, %{


### PR DESCRIPTION
validate_amount checks that the given amount does not exceed the player's remaining chips. However, the amount parameter includes the player's current_bet, so current_bet must be included as well when checking.