### PR TITLE
reset helper function + added raise_amount to over_the_top_all_in

### DIFF
--- a/lib/poker_mind/Engine/actions.ex
+++ b/lib/poker_mind/Engine/actions.ex
@@ -80,6 +80,7 @@ defmodule PokerMind.Engine.Actions do
     if all_in_amount > state.highest_raise do
       state
       |> TableState.update_highest_raise(all_in_amount)
+      |> TableState.update_raise_amount(all_in_amount - state.highest_raise)
       |> TableState.reset_has_acted()
     else
       state
@@ -165,9 +166,6 @@ defmodule PokerMind.Engine.Actions do
 
       amount - state.highest_raise >= state.raise_amount ->
         :ok
-
-      true ->
-        {:error, {:invalid_action, "Invalid action"}}
     end
   end
 
@@ -182,6 +180,7 @@ defmodule PokerMind.Engine.Actions do
         |> TableState.reset_has_acted()
         |> TableState.reset_current_bet()
         |> TableState.reset_highest_raise()
+        |> TableState.reset_raise_amount()
         |> TableState.advance_phase(next_phase)
 
       if advanced_state.phase in [:flop, :turn, :river] do

--- a/lib/poker_mind/Engine/tablestate.ex
+++ b/lib/poker_mind/Engine/tablestate.ex
@@ -389,7 +389,6 @@ defmodule PokerMind.Engine.TableState do
     Map.put(state, :raise_amount, 0)
   end
 
-
   def compare_cards(rank1, rank2)
       when is_integer(rank1) and is_integer(rank2) do
     rank1 = normalize_rank(rank1)

--- a/lib/poker_mind/Engine/tablestate.ex
+++ b/lib/poker_mind/Engine/tablestate.ex
@@ -385,6 +385,11 @@ defmodule PokerMind.Engine.TableState do
     Map.put(state, :highest_raise, 0)
   end
 
+  def reset_raise_amount(%__MODULE__{} = state) do
+    Map.put(state, :raise_amount, 0)
+  end
+
+
   def compare_cards(rank1, rank2)
       when is_integer(rank1) and is_integer(rank2) do
     rank1 = normalize_rank(rank1)


### PR DESCRIPTION
1. over_the_top_all_in now updates raise_amount ([actions.ex:79-87]
2. advance_player_turn() now includes new helper function that resets raise_amount between phases.
3. Deleted stale condition in validate_raise