### PR TITLE
conserve chips when a folded player over-contributed past the cap

### DIFF
--- a/lib/poker_mind/Engine/tablestate.ex
+++ b/lib/poker_mind/Engine/tablestate.ex
@@ -334,6 +334,21 @@ defmodule PokerMind.Engine.TableState do
       |> Enum.uniq()
       |> Enum.sort()
 
+    # Chips committed by folded players above the highest in-hand cap would
+    # otherwise be dropped: build_pots only emits layers up to that cap, so a
+    # folded player who over-contributed (e.g. a BB poster who folds to a
+    # sub-blind short all-in) loses chips that no in-hand player can match.
+    # Fold the forfeit into the topmost raw pot — it goes to whoever wins the
+    # layer at the highest in-hand cap, exactly as if the folder had checked
+    # down.
+    max_in_hand_cap = List.last(layers) || 0
+
+    folded_overbet =
+      players
+      |> Enum.filter(&(&1.state not in [:active_in_hand, :all_in]))
+      |> Enum.map(&max(0, &1.total_contributed - max_in_hand_cap))
+      |> Enum.sum()
+
     {raw_pots, _} =
       Enum.map_reduce(layers, 0, fn layer, prev_layer ->
         amount =
@@ -348,6 +363,17 @@ defmodule PokerMind.Engine.TableState do
 
         {%{amount: amount, eligible_ids: eligible_player_ids}, layer}
       end)
+
+    raw_pots =
+      case raw_pots do
+        [] ->
+          raw_pots
+
+        _ ->
+          List.update_at(raw_pots, -1, fn pot ->
+            Map.update!(pot, :amount, &(&1 + folded_overbet))
+          end)
+      end
 
     # Collapse single-eligible pots into refunds (uncontested middle/top layers).
     {pots, refunds} =

--- a/test/poker_mind/Engine/tablestate_test.exs
+++ b/test/poker_mind/Engine/tablestate_test.exs
@@ -526,6 +526,39 @@ defmodule PokerMind.Engine.TableStateTest do
       assert [%{amount: 200, eligible_ids: ["A", "B"]}] = result.pots
       assert [{"B", 400}] = result.refunds
     end
+
+    test "build_pots/1 - blinds fold to a sub-BB short all-in: forfeit absorbed by top pot" do
+      # Pot of 200 = SB 50 + BB 100 + UTG short all-in 50. Both blinds fold.
+      # Without the folded-overbet absorption, the BB poster's 50 chips above
+      # the in-hand cap (50) would silently disappear from the pot.
+      state =
+        pots_state([
+          {"alice", :all_in, 50},
+          {"bob", :inactive_in_hand, 100},
+          {"carol", :inactive_in_hand, 50}
+        ])
+
+      result = TableState.build_pots(state)
+      assert result.pots == []
+      assert result.refunds == [{"alice", 200}]
+    end
+
+    test "build_pots/1 - folded over-bet folds into single-eligible top side pot" do
+      # A all-in 200, B in-hand 500, folded C 700.
+      # Main pot {600, [A, B]} contested.
+      # Top layer {600, [B]} single-eligible → refund. Forfeit from C above
+      # the 500 cap (200) must be absorbed by that refund.
+      state =
+        pots_state([
+          {"A", :all_in, 200},
+          {"B", :active_in_hand, 500},
+          {"C", :inactive_in_hand, 700}
+        ])
+
+      result = TableState.build_pots(state)
+      assert result.pots == [%{amount: 600, eligible_ids: ["A", "B"]}]
+      assert result.refunds == [{"B", 800}]
+    end
   end
 
   describe "distribute_pots/1" do
@@ -614,6 +647,45 @@ defmodule PokerMind.Engine.TableStateTest do
       assert TableState.get_player(final, "B").remaining_chips == 331 - 50
       assert TableState.get_player(final, "C").remaining_chips == 330 - 100
       assert TableState.get_player(final, "D").remaining_chips == 0
+    end
+
+    test "distribute_pots/1 - blinds fold to sub-BB short all-in: chips conserved" do
+      # SB 50 + BB 100 + UTG sub-BB short all-in 50. Both blinds fold,
+      # leaving alice as the only player still in the hand. Total chips
+      # (stacks + pot) must be conserved across the showdown — the BB
+      # poster's 50 chips above the in-hand cap must not vanish.
+      community = [
+        %{rank: 2, suit: :diamonds},
+        %{rank: 7, suit: :clubs},
+        %{rank: 5, suit: :hearts},
+        %{rank: 9, suit: :clubs},
+        %{rank: 12, suit: :diamonds}
+      ]
+
+      players = [
+        showdown_player("alice", :all_in, 50, [
+          %{rank: 1, suit: :spades},
+          %{rank: 1, suit: :clubs}
+        ]),
+        showdown_player("bob", :inactive_in_hand, 100, [
+          %{rank: 4, suit: :spades},
+          %{rank: 8, suit: :clubs}
+        ]),
+        showdown_player("carol", :inactive_in_hand, 50, [
+          %{rank: 6, suit: :hearts},
+          %{rank: 10, suit: :clubs}
+        ])
+      ]
+
+      state = showdown_state(players, community)
+      before = state.pot + Enum.sum(Enum.map(state.players, & &1.remaining_chips))
+
+      final = TableState.distribute_pots(state)
+      after_total = final.pot + Enum.sum(Enum.map(final.players, & &1.remaining_chips))
+
+      assert before == after_total
+      assert final.pot == 0
+      assert TableState.get_player(final, "alice").remaining_chips == 200
     end
 
     test "distribute_pots/1 - all-in player wins main pot, bigger stack wins side pot" do


### PR DESCRIPTION
## Summary
`build_pots/1` derives pot layers exclusively from `players_still_in_hand`,
so any contribution from a *folded* player above the highest still-in-hand
cap is dropped — never placed in a pot, never refunded, zeroed out by the
`Map.put(:pot, 0)` at the end of `distribute_pots/1`.

In a normal hand this is unreachable, because under proper flow whoever
last "re-opened" action by raising/over-the-top'ing necessarily contributed
more than anyone whose action they re-opened. But forced blinds break
that invariant: a player with stack < big_blind can short-all-in,
the action remains open for the actual SB/BB to call/check/fold, and if
the BB (or SB) folds with their forced contribution above the all-in cap,
the chips above the cap vanish.

## Fix
After computing layers from `players_still_in_hand`, fold any folded
player's over-contribution (above the highest in-hand cap) into the
topmost raw pot. Folded players forfeit committed chips, so those
chips belong to the eligible winner of the layer that matches the
highest-contributing in-hand player(s) — exactly who would have
collected them at showdown if the folder had checked down. If that
top layer is single-eligible the existing reduce will collapse it
into a refund of the now-larger amount.