### PR TITLE
fix: reject :call when amount equals player's current_bet (use :check)

### DIFF
--- a/lib/poker_mind/Engine/actions.ex
+++ b/lib/poker_mind/Engine/actions.ex
@@ -31,7 +31,7 @@ defmodule PokerMind.Engine.Actions do
   def apply_action(%TableState{} = state, %{type: :call, player_id: player_id, amount: amount})
       when is_binary(player_id) do
     with :ok <- validate_turn(state, player_id),
-         :ok <- validate_call(state, amount),
+         :ok <- validate_call(state, player_id, amount),
          :ok <- validate_amount(state, player_id, amount) do
       state
       |> TableState.add_to_pot(player_id, amount)
@@ -141,12 +141,22 @@ defmodule PokerMind.Engine.Actions do
     end
   end
 
-  defp validate_call(%TableState{highest_raise: highest_raise}, amount) when is_integer(amount) do
-    if amount == highest_raise do
-      :ok
-    else
-      {:error,
-       {:invalid_call_amount, "Call amount #{amount} must match highest raise #{highest_raise}"}}
+  defp validate_call(%TableState{highest_raise: highest_raise} = state, player_id, amount)
+       when is_binary(player_id) and is_integer(amount) do
+    player = TableState.get_player(state, player_id)
+
+    cond do
+      amount != highest_raise ->
+        {:error,
+         {:invalid_call_amount, "Call amount #{amount} must match highest raise #{highest_raise}"}}
+
+      amount == player.current_bet ->
+        {:error,
+         {:use_check_action,
+          "No chips to call (current bet #{player.current_bet} already matches highest raise #{highest_raise}) - use the check action type"}}
+
+      true ->
+        :ok
     end
   end
 

--- a/test/poker_mind/Engine/actions_test.exs
+++ b/test/poker_mind/Engine/actions_test.exs
@@ -300,6 +300,39 @@ defmodule PokerMind.Engine.ActionsTest do
                  amount: 3 * init_state.highest_raise
                })
     end
+
+    test "call rejected when player's current_bet already matches highest_raise (use :check)",
+         %{state: init_state} do
+      # Big blind has already posted big_blind_amount and so current_bet == highest_raise.
+      # A :call at that amount would move 0 chips — point the caller at :check.
+      big_blind_id = TableState.find_next_active_player_id(init_state, init_state.small_blind_id)
+      bb_state = %{init_state | current_player_id: big_blind_id}
+
+      assert TableState.get_player(bb_state, big_blind_id).current_bet == bb_state.highest_raise
+
+      assert {:error, {:use_check_action, _}} =
+               Actions.apply_action(bb_state, %{
+                 type: :call,
+                 player_id: big_blind_id,
+                 amount: bb_state.highest_raise
+               })
+
+      # State unchanged on rejection (validators don't mutate).
+      assert TableState.get_player(bb_state, big_blind_id) ==
+               TableState.get_player(init_state, big_blind_id)
+    end
+
+    test "BB can :check when current_bet already matches highest_raise",
+         %{state: init_state} do
+      big_blind_id = TableState.find_next_active_player_id(init_state, init_state.small_blind_id)
+      bb_state = %{init_state | current_player_id: big_blind_id}
+
+      new_state = Actions.apply_action(bb_state, %{type: :check, player_id: big_blind_id})
+
+      assert TableState.get_player(new_state, big_blind_id).has_acted
+      assert new_state.current_player_id != big_blind_id
+      assert new_state.pot == bb_state.pot
+    end
   end
 
   describe "apply_action :all_in" do


### PR DESCRIPTION
## Summary
A `:call` whose amount matches the player's existing `current_bet`
moves zero chips and is semantically a `:check`. Today the engine
accepts it through `validate_call/2` and `validate_amount/3`, then
reaches `PlayerState.deduct_chips/3` with `amount_to_add = 0` and
crashes on the `amount > 0` guard.

Mirroring the established `:use_all_in_action` pattern in
`validate_amount/3` — where `amount == remaining_chips + current_bet`
is rejected with a "use the :all_in action type" error — we reject
the zero-cost call up front with a `:use_check_action` error
pointing the caller at `:check`.

## Fix
Extend `validate_call` to also know the acting player, and reject
calls whose amount equals the player's `current_bet` with the same
shape of error we already use for "this should be `:all_in`"