### PR TITLE
Fix/call without amount

### DIFF
--- a/lib/poker_mind/Engine/actions.ex
+++ b/lib/poker_mind/Engine/actions.ex
@@ -28,13 +28,13 @@ defmodule PokerMind.Engine.Actions do
     end
   end
 
-  def apply_action(%TableState{} = state, %{action: :call, player_id: player_id, amount: amount})
+  def apply_action(%TableState{} = state, %{action: :call, player_id: player_id})
       when is_binary(player_id) do
     with :ok <- validate_turn(state, player_id),
-         :ok <- validate_call(state, player_id, amount),
-         :ok <- validate_amount(state, player_id, amount) do
+         :ok <- validate_call(state, player_id),
+         :ok <- validate_amount(state, player_id, state.highest_raise) do
       state
-      |> TableState.add_to_pot(player_id, amount)
+      |> TableState.add_to_pot(player_id, state.highest_raise)
       |> advance_player_turn(:call)
     end
   end
@@ -141,22 +141,16 @@ defmodule PokerMind.Engine.Actions do
     end
   end
 
-  defp validate_call(%TableState{highest_raise: highest_raise} = state, player_id, amount)
-       when is_binary(player_id) and is_integer(amount) do
+  defp validate_call(%TableState{highest_raise: highest_raise} = state, player_id)
+       when is_binary(player_id) do
     player = TableState.get_player(state, player_id)
 
-    cond do
-      amount != highest_raise ->
-        {:error,
-         {:invalid_call_amount, "Call amount #{amount} must match highest raise #{highest_raise}"}}
-
-      amount == player.current_bet ->
-        {:error,
-         {:use_check_action,
-          "No chips to call (current bet #{player.current_bet} already matches highest raise #{highest_raise}) - use the check action type"}}
-
-      true ->
-        :ok
+    if player.current_bet == highest_raise do
+      {:error,
+       {:use_check_action,
+        "No chips to call (current bet #{player.current_bet} already matches highest raise #{highest_raise}) - use the check action type"}}
+    else
+      :ok
     end
   end
 

--- a/test/poker_mind/Engine/actions_test.exs
+++ b/test/poker_mind/Engine/actions_test.exs
@@ -242,8 +242,7 @@ defmodule PokerMind.Engine.ActionsTest do
       new_state =
         Actions.apply_action(new_state, %{
           action: :call,
-          player_id: next_player_id,
-          amount: 2 * init_state.highest_raise
+          player_id: next_player_id
         })
 
       # check that the calling player is still :active_in_hand
@@ -261,46 +260,6 @@ defmodule PokerMind.Engine.ActionsTest do
       assert next_player_remaining_chips == starting_stack - 2 * init_state.highest_raise
     end
 
-    test "call rejects amount less than highest_raise", %{state: init_state} do
-      starting_player_id = init_state.current_player_id
-
-      raised_state =
-        Actions.apply_action(init_state, %{
-          action: :raise,
-          player_id: starting_player_id,
-          amount: 2 * init_state.highest_raise
-        })
-
-      next_player_id = raised_state.current_player_id
-
-      assert {:error, {:invalid_call_amount, _}} =
-               Actions.apply_action(raised_state, %{
-                 action: :call,
-                 player_id: next_player_id,
-                 amount: init_state.highest_raise
-               })
-    end
-
-    test "call rejects amount greater than highest_raise", %{state: init_state} do
-      starting_player_id = init_state.current_player_id
-
-      raised_state =
-        Actions.apply_action(init_state, %{
-          action: :raise,
-          player_id: starting_player_id,
-          amount: 2 * init_state.highest_raise
-        })
-
-      next_player_id = raised_state.current_player_id
-
-      assert {:error, {:invalid_call_amount, _}} =
-               Actions.apply_action(raised_state, %{
-                 action: :call,
-                 player_id: next_player_id,
-                 amount: 3 * init_state.highest_raise
-               })
-    end
-
     test "call rejected when player's current_bet already matches highest_raise (use :check)",
          %{state: init_state} do
       # Big blind has already posted big_blind_amount and so current_bet == highest_raise.
@@ -312,9 +271,8 @@ defmodule PokerMind.Engine.ActionsTest do
 
       assert {:error, {:use_check_action, _}} =
                Actions.apply_action(bb_state, %{
-                 type: :call,
-                 player_id: big_blind_id,
-                 amount: bb_state.highest_raise
+                 action: :call,
+                 player_id: big_blind_id
                })
 
       # State unchanged on rejection (validators don't mutate).
@@ -327,7 +285,7 @@ defmodule PokerMind.Engine.ActionsTest do
       big_blind_id = TableState.find_next_active_player_id(init_state, init_state.small_blind_id)
       bb_state = %{init_state | current_player_id: big_blind_id}
 
-      new_state = Actions.apply_action(bb_state, %{type: :check, player_id: big_blind_id})
+      new_state = Actions.apply_action(bb_state, %{action: :check, player_id: big_blind_id})
 
       assert TableState.get_player(new_state, big_blind_id).has_acted
       assert new_state.current_player_id != big_blind_id
@@ -424,7 +382,7 @@ defmodule PokerMind.Engine.ActionsTest do
       p2 = after_raise.current_player_id
 
       after_call =
-        Actions.apply_action(after_raise, %{action: :call, player_id: p2, amount: 800})
+        Actions.apply_action(after_raise, %{action: :call, player_id: p2})
 
       assert TableState.get_player(after_call, p1).has_acted
       assert TableState.get_player(after_call, p2).has_acted
@@ -451,7 +409,7 @@ defmodule PokerMind.Engine.ActionsTest do
       p2 = after_raise.current_player_id
 
       after_call =
-        Actions.apply_action(after_raise, %{action: :call, player_id: p2, amount: 500})
+        Actions.apply_action(after_raise, %{action: :call, player_id: p2})
 
       p3 = after_call.current_player_id
       # Hard-coding player 3's remaining chips to perform all-in which matches the highest raise
@@ -476,7 +434,7 @@ defmodule PokerMind.Engine.ActionsTest do
       p2 = after_raise.current_player_id
 
       after_call =
-        Actions.apply_action(after_raise, %{action: :call, player_id: p2, amount: 500})
+        Actions.apply_action(after_raise, %{action: :call, player_id: p2})
 
       assert TableState.get_player(after_call, p1).has_acted
       assert TableState.get_player(after_call, p2).has_acted
@@ -624,8 +582,7 @@ defmodule PokerMind.Engine.ActionsTest do
       assert {:error, {:use_all_in_action, _}} =
                Actions.apply_action(call_state, %{
                  action: :call,
-                 player_id: starting_player_id,
-                 amount: call_state.highest_raise
+                 player_id: starting_player_id
                })
     end
 
@@ -754,8 +711,7 @@ defmodule PokerMind.Engine.ActionsTest do
       call_state =
         Actions.apply_action(raise_state, %{
           action: :call,
-          player_id: call_player_id,
-          amount: 2 * init_state.highest_raise
+          player_id: call_player_id
         })
 
       # did call action go through?
@@ -781,8 +737,7 @@ defmodule PokerMind.Engine.ActionsTest do
         Enum.reduce(1..3, raised, fn _, s ->
           Actions.apply_action(s, %{
             action: :call,
-            player_id: s.current_player_id,
-            amount: 2 * init_state.highest_raise
+            player_id: s.current_player_id
           })
         end)
 

--- a/test/poker_mind/Engine/actions_test.exs
+++ b/test/poker_mind/Engine/actions_test.exs
@@ -242,8 +242,7 @@ defmodule PokerMind.Engine.ActionsTest do
       new_state =
         Actions.apply_action(new_state, %{
           action: :call,
-          player_id: next_player_id,
-          amount: 2 * init_state.highest_raise
+          player_id: next_player_id
         })
 
       # check that the calling player is still :active_in_hand
@@ -261,46 +260,6 @@ defmodule PokerMind.Engine.ActionsTest do
       assert next_player_remaining_chips == starting_stack - 2 * init_state.highest_raise
     end
 
-    test "call rejects amount less than highest_raise", %{state: init_state} do
-      starting_player_id = init_state.current_player_id
-
-      raised_state =
-        Actions.apply_action(init_state, %{
-          action: :raise,
-          player_id: starting_player_id,
-          amount: 2 * init_state.highest_raise
-        })
-
-      next_player_id = raised_state.current_player_id
-
-      assert {:error, {:invalid_call_amount, _}} =
-               Actions.apply_action(raised_state, %{
-                 action: :call,
-                 player_id: next_player_id,
-                 amount: init_state.highest_raise
-               })
-    end
-
-    test "call rejects amount greater than highest_raise", %{state: init_state} do
-      starting_player_id = init_state.current_player_id
-
-      raised_state =
-        Actions.apply_action(init_state, %{
-          action: :raise,
-          player_id: starting_player_id,
-          amount: 2 * init_state.highest_raise
-        })
-
-      next_player_id = raised_state.current_player_id
-
-      assert {:error, {:invalid_call_amount, _}} =
-               Actions.apply_action(raised_state, %{
-                 action: :call,
-                 player_id: next_player_id,
-                 amount: 3 * init_state.highest_raise
-               })
-    end
-
     test "call rejected when player's current_bet already matches highest_raise (use :check)",
          %{state: init_state} do
       # Big blind has already posted big_blind_amount and so current_bet == highest_raise.
@@ -313,8 +272,7 @@ defmodule PokerMind.Engine.ActionsTest do
       assert {:error, {:use_check_action, _}} =
                Actions.apply_action(bb_state, %{
                  action: :call,
-                 player_id: big_blind_id,
-                 amount: bb_state.highest_raise
+                 player_id: big_blind_id
                })
 
       # State unchanged on rejection (validators don't mutate).
@@ -424,7 +382,7 @@ defmodule PokerMind.Engine.ActionsTest do
       p2 = after_raise.current_player_id
 
       after_call =
-        Actions.apply_action(after_raise, %{action: :call, player_id: p2, amount: 800})
+        Actions.apply_action(after_raise, %{action: :call, player_id: p2})
 
       assert TableState.get_player(after_call, p1).has_acted
       assert TableState.get_player(after_call, p2).has_acted
@@ -451,7 +409,7 @@ defmodule PokerMind.Engine.ActionsTest do
       p2 = after_raise.current_player_id
 
       after_call =
-        Actions.apply_action(after_raise, %{action: :call, player_id: p2, amount: 500})
+        Actions.apply_action(after_raise, %{action: :call, player_id: p2})
 
       p3 = after_call.current_player_id
       # Hard-coding player 3's remaining chips to perform all-in which matches the highest raise
@@ -476,7 +434,7 @@ defmodule PokerMind.Engine.ActionsTest do
       p2 = after_raise.current_player_id
 
       after_call =
-        Actions.apply_action(after_raise, %{action: :call, player_id: p2, amount: 500})
+        Actions.apply_action(after_raise, %{action: :call, player_id: p2})
 
       assert TableState.get_player(after_call, p1).has_acted
       assert TableState.get_player(after_call, p2).has_acted
@@ -624,8 +582,7 @@ defmodule PokerMind.Engine.ActionsTest do
       assert {:error, {:use_all_in_action, _}} =
                Actions.apply_action(call_state, %{
                  action: :call,
-                 player_id: starting_player_id,
-                 amount: call_state.highest_raise
+                 player_id: starting_player_id
                })
     end
 
@@ -754,8 +711,7 @@ defmodule PokerMind.Engine.ActionsTest do
       call_state =
         Actions.apply_action(raise_state, %{
           action: :call,
-          player_id: call_player_id,
-          amount: 2 * init_state.highest_raise
+          player_id: call_player_id
         })
 
       # did call action go through?
@@ -781,8 +737,7 @@ defmodule PokerMind.Engine.ActionsTest do
         Enum.reduce(1..3, raised, fn _, s ->
           Actions.apply_action(s, %{
             action: :call,
-            player_id: s.current_player_id,
-            amount: 2 * init_state.highest_raise
+            player_id: s.current_player_id
           })
         end)
 


### PR DESCRIPTION
actions.ex:31-40 — validate_call/2 instead of /3, no longer threading amount into the validator.
actions.ex:144-155 — validate_call simplified from cond to if; the unreachable :invalid_call_amount branch is gone.
actions_test.exs — both now-impossible tests deleted, :use_check_action test kept as the remaining :call-rejection coverage.